### PR TITLE
Fix health check bug

### DIFF
--- a/server/plugin/registry/etcd/common.go
+++ b/server/plugin/registry/etcd/common.go
@@ -23,7 +23,8 @@ import (
 const (
 	// here will new an etcd connection after about 30s(=5s * 3 + (backoff:8s))
 	// when the connected etcd member was hung but tcp is still alive
-	healthCheckTimeout = 5 * time.Second
+	healthCheckTimeout    = 5 * time.Second
+	healthCheckRetryTimes = 3
 
 	// see google.golang.org/grpc/keepalive/keepalive.go
 	// after a duration of this time if the client doesn't see any activity

--- a/server/plugin/registry/etcd/etcd_test.go
+++ b/server/plugin/registry/etcd/etcd_test.go
@@ -565,7 +565,6 @@ func TestEtcdClient_HealthCheck(t *testing.T) {
 
 	etcdc.Endpoints = []string{endpoint}
 
-	etcdc.Close()
 	ctx, _ = context.WithTimeout(context.Background(), 1*time.Second)
 	go etcdc.healthCheckLoop(ctx)
 	for {


### PR DESCRIPTION
修复问题：健康检查成功时reopen了etcd client，导致旧client被close，使用旧client的请求报错：`grpc: the client connection is closing`。修改为：只有健康检查失败才reopen etcd client。

https://github.com/apache/servicecomb-service-center/blob/3a32227ecc38b431c725209a0a413524eec3992f/server/plugin/registry/etcd/etcd.go#L746-L758


Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `go build` `go test` `go fmt` `go vet` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
