### PR TITLE
[Enhancement] implement ms datasource register service in etcd mode

### DIFF
--- a/server/service/microservice_test.go
+++ b/server/service/microservice_test.go
@@ -22,9 +22,6 @@ import (
 	"github.com/apache/servicecomb-service-center/server/core/proto"
 	"github.com/apache/servicecomb-service-center/server/plugin/quota"
 	scerr "github.com/apache/servicecomb-service-center/server/scerror"
-	"github.com/apache/servicecomb-service-center/server/service/ms"
-	"github.com/apache/servicecomb-service-center/server/service/ms/etcd"
-	"github.com/go-chassis/go-archaius"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"strconv"
@@ -49,22 +46,6 @@ var _ = Describe("'Micro-service' service", func() {
 				resp, err := serviceResource.Create(getContext(), &pb.CreateServiceRequest{
 					Service: nil,
 				})
-				Expect(err).To(BeNil())
-				Expect(resp.Response.GetCode()).To(Equal(scerr.ErrInvalidParams))
-			})
-
-			It("ms datasource etcd mode: should not be passed", func() {
-				ms.Install("etcd",
-					func(opts ms.Options) (ms.DataSource, error) {
-						return etcd.NewDataSource(), nil
-					})
-
-				// sc main function initialize step
-				err := ms.Init(ms.Options{
-					Endpoint:       "",
-					PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
-				})
-				resp, err := ms.MicroService().RegisterService(getContext(), &pb.CreateServiceRequest{Service: nil})
 				Expect(err).To(BeNil())
 				Expect(resp.Response.GetCode()).To(Equal(scerr.ErrInvalidParams))
 			})

--- a/server/service/ms/datasource.go
+++ b/server/service/ms/datasource.go
@@ -18,10 +18,11 @@ package ms
 import (
 	"context"
 	pb "github.com/apache/servicecomb-service-center/pkg/registry"
+	"github.com/apache/servicecomb-service-center/server/plugin/registry"
 )
 
 type DataSource interface {
-	RegisterService(ctx context.Context, service *pb.CreateServiceRequest) (*pb.CreateServiceResponse, error)
+	RegisterService(ctx context.Context, service *pb.CreateServiceRequest) (*registry.PluginResponse, error)
 	GetService(ctx context.Context, service *pb.GetServiceRequest)
 	UpdateService(ctx context.Context, service *pb.UpdateServicePropsRequest)
 	UnregisterService(ctx context.Context, service *pb.DeleteServiceRequest)

--- a/server/service/ms/etcd/etcd_suite_test.go
+++ b/server/service/ms/etcd/etcd_suite_test.go
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package etcd_test
+
+// initialize
+import (
+	_ "github.com/apache/servicecomb-service-center/server/bootstrap"
+)
+import (
+	"context"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/apache/servicecomb-service-center/server/core"
+	"github.com/astaxie/beego"
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func init() {
+	beego.AppConfig.Set("registry_plugin", "etcd")
+	testing.Init()
+	core.Initialize()
+}
+
+var _ = BeforeSuite(func() {
+	//init plugin
+	core.ServerInfo.Config.EnableCache = false
+})
+
+func getContext() context.Context {
+	return util.SetContext(
+		util.SetDomainProject(context.Background(), "default", "default"),
+		util.CtxNocache, "1")
+}
+
+func TestGrpc(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("model.junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "model Suite", []Reporter{junitReporter})
+}

--- a/server/service/ms/etcd/etcd_test.go
+++ b/server/service/ms/etcd/etcd_test.go
@@ -1,0 +1,177 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd_test
+
+import (
+	pb "github.com/apache/servicecomb-service-center/pkg/registry"
+	"github.com/apache/servicecomb-service-center/server/plugin/quota"
+	"github.com/apache/servicecomb-service-center/server/service/ms"
+	"github.com/apache/servicecomb-service-center/server/service/ms/etcd"
+	"github.com/go-chassis/go-archaius"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	TooLongAppId       = strings.Repeat("x", 162)
+	TooLongSchemaId    = strings.Repeat("x", 162)
+	TooLongServiceName = strings.Repeat("x", 130)
+	TooLongAlias       = strings.Repeat("x", 130)
+	TooLongFramework   = strings.Repeat("x", 66)
+)
+
+func TestInit(t *testing.T) {
+	_ = archaius.Init(archaius.WithMemorySource())
+	_ = archaius.Set("servicecomb.ms.name", "etcd")
+
+	t.Run("Register service after init & install, should pass", func(t *testing.T) {
+		ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
+			return etcd.NewDataSource(), nil
+		})
+
+		err := ms.Init(ms.Options{
+			Endpoint:       "",
+			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
+		})
+		assert.NoError(t, err)
+
+		size := quota.DefaultSchemaQuota + 1
+		paths := make([]*pb.ServicePath, 0, size)
+		properties := make(map[string]string, size)
+		for i := 0; i < size; i++ {
+			s := strconv.Itoa(i) + strings.Repeat("x", 253)
+			paths = append(paths, &pb.ServicePath{Path: s, Property: map[string]string{s: s}})
+			properties[s] = s
+		}
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				AppId:       TooLongAppId[:len(TooLongAppId)-1],
+				ServiceName: TooLongServiceName[:len(TooLongServiceName)-1],
+				Version:     "32767.32767.32767.32767",
+				Alias:       TooLongAlias[:len(TooLongAlias)-1],
+				Level:       "BACK",
+				Status:      "UP",
+				Schemas:     []string{TooLongSchemaId[:len(TooLongSchemaId)-1]},
+				Paths:       paths,
+				Properties:  properties,
+				Framework: &pb.FrameWorkProperty{
+					Name:    TooLongFramework[:len(TooLongFramework)-1],
+					Version: TooLongFramework[:len(TooLongFramework)-1],
+				},
+				RegisterBy: "SDK",
+				Timestamp:  strconv.FormatInt(time.Now().Unix(), 10),
+			},
+		}
+		request.Service.ModTimestamp = request.Service.Timestamp
+		resp, err := ms.MicroService().RegisterService(getContext(), request)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Succeeded)
+	})
+
+	t.Run("register service with framework name nil", func(t *testing.T) {
+		ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
+			return etcd.NewDataSource(), nil
+		})
+
+		err := ms.Init(ms.Options{
+			Endpoint:       "",
+			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
+		})
+		assert.NoError(t, err)
+
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceName: "framework-test-ms",
+				AppId:       "default",
+				Version:     "1.0.1",
+				Level:       "BACK",
+				Framework: &pb.FrameWorkProperty{
+					Version: "1.0.0",
+				},
+				Properties: make(map[string]string),
+				Status:     "UP",
+			},
+		}
+
+		resp, err := ms.MicroService().RegisterService(getContext(), request)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Succeeded)
+	})
+
+	t.Run("register service with framework version nil", func(t *testing.T) {
+		ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
+			return etcd.NewDataSource(), nil
+		})
+		err := ms.Init(ms.Options{
+			Endpoint:       "",
+			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
+		})
+		assert.NoError(t, err)
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceName: "framework-test-ms",
+				AppId:       "default",
+				Version:     "1.0.2",
+				Level:       "BACK",
+				Framework: &pb.FrameWorkProperty{
+					Name: "framework",
+				},
+				Properties: make(map[string]string),
+				Status:     "UP",
+			},
+		}
+
+		resp, err := ms.MicroService().RegisterService(getContext(), request)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Succeeded)
+	})
+
+	t.Run("register service with status is nil", func(t *testing.T) {
+		ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
+			return etcd.NewDataSource(), nil
+		})
+		err := ms.Init(ms.Options{
+			Endpoint:       "",
+			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
+		})
+		assert.NoError(t, err)
+
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceName: "status-test-ms",
+				AppId:       "default",
+				Version:     "1.0.3",
+				Level:       "BACK",
+				Properties:  make(map[string]string),
+			},
+		}
+
+		resp, err := ms.MicroService().RegisterService(getContext(), request)
+
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Succeeded)
+	})
+}

--- a/server/service/ms/manager_test.go
+++ b/server/service/ms/manager_test.go
@@ -13,13 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ms
+package ms_test
 
 import (
-	"context"
-	pb "github.com/apache/servicecomb-service-center/pkg/registry"
-	"github.com/apache/servicecomb-service-center/pkg/util"
-	scerr "github.com/apache/servicecomb-service-center/server/scerror"
+	"github.com/apache/servicecomb-service-center/server/service/ms"
 	"github.com/apache/servicecomb-service-center/server/service/ms/etcd"
 	"github.com/go-chassis/go-archaius"
 	"github.com/stretchr/testify/assert"
@@ -29,41 +26,21 @@ import (
 func TestInit(t *testing.T) {
 	_ = archaius.Init(archaius.WithMemorySource())
 	_ = archaius.Set("servicecomb.ms.name", "etcd")
-	t.Run("circuit microservice data source plugin", func(t *testing.T) {
-		err := Init(Options{
+	t.Run("init microservice data source plugin, should pass", func(t *testing.T) {
+		err := ms.Init(ms.Options{
 			Endpoint:       "",
 			PluginImplName: "",
 		})
 		assert.NoError(t, err)
 	})
-	t.Run("microservice data source plugin install and init", func(t *testing.T) {
-		Install("etcd", func(opts Options) (DataSource, error) {
+	t.Run("install and init microservice data source plugin, should pass", func(t *testing.T) {
+		ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
 			return etcd.NewDataSource(), nil
 		})
-		err := Init(Options{
+		err := ms.Init(ms.Options{
 			Endpoint:       "",
-			PluginImplName: ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
+			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
 		})
 		assert.NoError(t, err)
 	})
-	t.Run("Register service,should success", func(t *testing.T) {
-		Install("etcd", func(opts Options) (DataSource, error) {
-			return etcd.NewDataSource(), nil
-		})
-
-		err := Init(Options{
-			Endpoint:       "",
-			PluginImplName: ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
-		})
-		assert.NoError(t, err)
-		resp, err := MicroService().RegisterService(getContext(), &pb.CreateServiceRequest{Service: nil})
-		assert.NotNil(t, resp)
-		assert.Equal(t, resp.Response.GetCode(), scerr.ErrInvalidParams)
-	})
-}
-
-func getContext() context.Context {
-	return util.SetContext(
-		util.SetDomainProject(context.Background(), "default", "default"),
-		util.CtxNocache, "1")
 }

--- a/server/service/ms/options.go
+++ b/server/service/ms/options.go
@@ -19,4 +19,6 @@ package ms
 type Options struct {
 	Endpoint       string
 	PluginImplName ImplName
+
+	// TODO: pay attention to more net config like TLSConfig when coding
 }


### PR DESCRIPTION
### Pull request message
Implement ms datasource register service in etcd mode.

### History pr:
+ datasource framework: https://github.com/apache/servicecomb-service-center/pull/695

### Target
Refactoring service-center to make it support different backend storage(Etcd, Mongo, etc.) and kv design
### Background
At this point, register-information from services in mesh could be stored in etcd cluster(embeded or isolated-cluster) with a certain kv design format(see the design example [here](https://github.com/apache/servicecomb-service-center/blob/master/examples/etcd_data_struct.yaml)).
### Problem
Howere, the service-comb can not make it if new kv design format from another database want to be introduced to the project. For example, kv format will be designed like [this](https://github.com/apache/servicecomb-service-center/blob/master/examples/mongodb_data_struct.yaml) when we take mongo into consideration.
### Enhancement
So, I'd like to **abstract kv constructing operation from api service layer to modules named datasource**, where the module acts like shim between backend databse and api bussiness layer. They act as a plugin located in server/service/dep, server/service/auth, server/service/ms.
**The storageShim module will construct request metada from service-resigter-api to different kv according to different backend storage cluster.**
### Changes after refactoring
Take the service information register as a example.
#### Before refactoring
```go
// api layer
func CreateServicePri(ctx context, request CreateServiceRequest) {
        // parameter validation
        // tracing

        // construct kv in etcd-cluster format
    	serviceKey := &pb.MicroServiceKey{
		Tenant:      domainProject,
		Environment: service.Environment,
		AppId:       service.AppId,
		ServiceName: service.ServiceName,
		Alias:       service.Alias,
		Version:     service.Version,
	}
	index := apt.GenerateServiceIndexKey(serviceKey)
	key := apt.GenerateServiceKey(domainProject, service.ServiceId)
	keyBytes := util.StringToBytesWithNoCopy(key)
	indexBytes := util.StringToBytesWithNoCopy(index)
	aliasBytes := util.StringToBytesWithNoCopy(apt.GenerateServiceAliasKey(serviceKey))

	opts := []registry.PluginOp{
		registry.OpPut(registry.WithKey(keyBytes), registry.WithValue(data)),
		registry.OpPut(registry.WithKey(indexBytes), registry.WithStrValue(service.ServiceId)),
	}
	uniqueCmpOpts := []registry.CompareOp{
		registry.OpCmp(registry.CmpVer(indexBytes), registry.CmpEqual, 0),
		registry.OpCmp(registry.CmpVer(keyBytes), registry.CmpEqual, 0),
	}
	failOpts := []registry.PluginOp{
		registry.OpGet(registry.WithKey(indexBytes)),
	}

        // call etcd client to store metadata
       	resp, err := backend.Registry().TxnWithCmp(ctx, opts, uniqueCmpOpts, failOpts)

       // resp check

      return resp, err
}
```
#### After refactor
``` go
// scserver start up main.go
func main.go() {
        // init a instance
       err := ms.Init(ms.Options{
			Endpoint:       "",
			PluginImplName: ms.ImplName(archaius.GetString("servicecomb.ms.name", "etcd")),
		})
        // err check
}

// api layer
func CreateServicePri(ctx context, request CreateServiceRequest) {
        // parameter validation
        // quota check

        // call etcd client to store metadata
       	resp, err := ms.MicroService().RegisterService(ctx, request)
       
        // resp check

      return resp, err
}
```
**Attention**: datasource act as a kv wrapper according to the interface implementor, will not do parameter and response validation
``` go
// datasource module

// ms etcd implement
// install ms plugin
func init() {
        ms.Install("etcd", func(opts ms.Options) (ms.DataSource, error) {
			return etcd.NewDataSource(), nil
		})
}
type DataSource struct{}
func NewDataSource() *DataSource {
	// TODO: construct a reasonable DataSource instance
	log.Warnf("microservice mgt data source enable etcd mode")

	inst := &DataSource{}
	if err := inst.initialize(); err != nil {
		return inst
	}
	return inst
}

// RegisterService implement
func RegisterService(ctx context, request CreateServiceRequest) (*registry.PluginResponse, error) {
        // construct kv in etcd-cluster format
    	 opts, uniqueCmpOpts, failOpts := constructEtcdFormat(ctx, request)
        resp, err := backend.Registry().TxnWithCmp(ctx, opts, uniqueCmpOpts, failOpts)
        return resp, err
}

// ms mongo implement
func RegisterService(ctx context, request CreateServiceRequest) (*registry.PluginResponse, error) {
        // construct kv in etcd-cluster format
    	 key, val := constructMongoFormat(ctx, request)
        resp, err := backend.Registry().TxnWithCmp(ctx, key, val)
        return resp, err
}
```
UT for example can be refered [here](https://github.com/apache/servicecomb-service-center/blob/5e390e7e6ff880dd282dd631deb726e8a3a99d64/server/service/microservice_test.go#L46)
