### PR TITLE
[enhancement] optimize service/util func invoker in ms/etcd package

### DIFF
--- a/server/service/dep/etcd/util.go
+++ b/server/service/dep/etcd/util.go
@@ -14,23 +14,3 @@
 // limitations under the License.
 
 package etcd
-
-import (
-	"encoding/json"
-	pb "github.com/apache/servicecomb-service-center/pkg/registry"
-	apt "github.com/apache/servicecomb-service-center/server/core"
-	"github.com/apache/servicecomb-service-center/server/plugin/registry"
-)
-
-func DeleteDependencyForDeleteService(domainProject string, serviceID string, service *pb.MicroServiceKey) (registry.PluginOp, error) {
-	key := apt.GenerateConsumerDependencyQueueKey(domainProject, serviceID, apt.DepsQueueUUID)
-	conDep := new(pb.ConsumerDependency)
-	conDep.Consumer = service
-	conDep.Providers = []*pb.MicroServiceKey{}
-	conDep.Override = true
-	data, err := json.Marshal(conDep)
-	if err != nil {
-		return registry.PluginOp{}, err
-	}
-	return registry.OpPut(registry.WithStrKey(key), registry.WithValue(data)), nil
-}


### PR DESCRIPTION
### commit message
+ Keep util functions under service/util still  be used by ms/etcd/etcd.go as serviceUtil.xxx.
    > Reason: functions in xxx_util.go under service/util  invoke each other, when we migrate these xxx_util.go-functions to service/ms/etcd/utils.go and service/dep/etcd/utils.go, it will lead package loop dependency error and blocked in  golang-lint check.
+ In the future, for different implementation of datasource interface, such as  mongo, util funcs can works under directory service/util/mongo

### History PR:
#703 -- service/ms interface implement
#701 -- service/ms interface implement
#698 -- service/ms interface implement
#697 -- background of the enhancement, service/ms interface implement
#695 -- framework of the enhancement