### PR TITLE
SCB-2094 implement basic service/rule/schema/tag interface

### DIFF
--- a/datasource/etcd/ms.go
+++ b/datasource/etcd/ms.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/etcd/cache"
 	"github.com/apache/servicecomb-service-center/datasource/etcd/client"
 	registry "github.com/apache/servicecomb-service-center/datasource/etcd/client"
@@ -2182,7 +2183,7 @@ func (ds *DataSource) modifySchemas(ctx context.Context, domainProject string, s
 	}
 
 	needUpdateSchemas, needAddSchemas, needDeleteSchemas, nonExistSchemaIds :=
-		schemasAnalysis(schemas, schemasFromDatabase, service.Schemas)
+		datasource.SchemasAnalysis(schemas, schemasFromDatabase, service.Schemas)
 
 	pluginOps := make([]client.PluginOp, 0)
 	if !ds.isSchemaEditable(service) {

--- a/datasource/mongo/account_test.go
+++ b/datasource/mongo/account_test.go
@@ -32,7 +32,7 @@ func init() {
 	config := storage.DB{
 		URI: "mongodb://localhost:27017",
 	}
-	client.NewMongoClient(config, []string{mongo.CollectionAccount})
+	client.NewMongoClient(config, []string{mongo.CollectionService, mongo.CollectionRule, mongo.CollectionSchema, mongo.CollectionAccount})
 }
 
 func TestCreateAccount(t *testing.T) {

--- a/datasource/mongo/client/errortypes.go
+++ b/datasource/mongo/client/errortypes.go
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import "go.mongodb.org/mongo-driver/mongo"
+
+const (
+	DuplicateKey = 11000
+)
+
+func IsDuplicateKey(err error) bool {
+	if err != nil {
+		we, ok := err.(mongo.WriteException)
+		if ok {
+			for _, wr := range we.WriteErrors {
+				if wr.Code == DuplicateKey {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/datasource/mongo/database.go
+++ b/datasource/mongo/database.go
@@ -24,7 +24,6 @@ import (
 
 const (
 	DuplicateKey               = 11000
-	CollectionAccount          = "account"
 	AccountName                = "name"
 	AccountID                  = "id"
 	AccountPassword            = "password"
@@ -32,11 +31,71 @@ const (
 	AccountTokenExpirationTime = "tokenexpirationtime"
 	AccountCurrentPassword     = "currentpassword"
 	AccountStatus              = "status"
-	CollectionInstance         = "instance"
 	InstanceID                 = "instanceinfo.instanceid"
 	ServiceID                  = "instanceinfo.serviceid"
 	RefreshTime                = "refreshtime"
 )
+
+const (
+	CollectionAccount  = "account"
+	CollectionService  = "service"
+	CollectionSchema   = "schema"
+	CollectionRule     = "rule"
+	CollectionInstance = "instance"
+)
+
+const (
+	ErrorDuplicateKey = 11000
+)
+
+const (
+	Domain             = "domain"
+	Project            = "project"
+	ServiceTag         = "tags"
+	SchemaID           = "schemaid"
+	RuleServiceID      = "serviceid"
+	RuleRuleID         = "ruleinfo.ruleid"
+	SchemaServiceID    = "serviceid"
+	ServiceServiceID   = "serviceinfo.serviceid"
+	ServiceProperty    = "serviceinfo.properties"
+	ServiceModTime     = "serviceinfo.modtimestamp"
+	ServiceEnv         = "serviceinfo.environment"
+	ServiceAppID       = "serviceinfo.appid"
+	ServiceServiceName = "serviceinfo.servicename"
+	ServiceAlias       = "serviceinfo.alias"
+	ServiceVersion     = "serviceinfo.version"
+	ServiceSchemas     = "serviceinfo.schemas"
+	RuleAttribute      = "ruleinfo.attribute"
+	RulePattern        = "ruleinfo.pattern"
+	RuleModTime        = "ruleinfo.modtimestamp"
+	RuleDescription    = "ruleinfo.description"
+	RuleRuletype       = "ruleinfo.ruletype"
+	SchemaInfo         = "schemainfo"
+	SchemaSummary      = "schemasummary"
+)
+
+type Service struct {
+	Domain      string
+	Project     string
+	Tags        map[string]string
+	ServiceInfo *pb.MicroService
+}
+
+type Schema struct {
+	Domain        string
+	Project       string
+	ServiceID     string
+	SchemaID      string
+	SchemaInfo    string
+	SchemaSummary string
+}
+
+type Rule struct {
+	Domain    string
+	Project   string
+	ServiceID string
+	RuleInfo  *pb.ServiceRule
+}
 
 type Instance struct {
 	Domain       string

--- a/datasource/mongo/ms.go
+++ b/datasource/mongo/ms.go
@@ -19,55 +19,1328 @@ package mongo
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/heartbeat"
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	apt "github.com/apache/servicecomb-service-center/server/core"
+	"github.com/apache/servicecomb-service-center/server/plugin/uuid"
 	pb "github.com/go-chassis/cari/discovery"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"strconv"
+	"time"
 )
 
 func (ds *DataSource) RegisterService(ctx context.Context, request *pb.CreateServiceRequest) (
 	*pb.CreateServiceResponse, error) {
-	return &pb.CreateServiceResponse{}, nil
+	service := request.Service
+
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	//todo add quota check
+	requestServiceID := service.ServiceId
+
+	if len(requestServiceID) == 0 {
+		ctx = util.SetContext(ctx, uuid.ContextKey, util.StringJoin([]string{domain, project, service.Environment, service.AppId, service.ServiceName, service.Alias, service.Version}, "/"))
+		service.ServiceId = uuid.Generator().GetServiceID(ctx)
+	}
+	// the service unique index in table is (serviceId,serviceEnv,serviceAppid,servicename,serviceAlias,serviceVersion)
+	existID, err := ServiceExistID(ctx, service.ServiceId)
+	if err != nil {
+		return &pb.CreateServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Check service exist failed"),
+		}, err
+	}
+	exist, err := ServiceExist(ctx, &pb.MicroServiceKey{
+		Environment: service.Environment,
+		AppId:       service.AppId,
+		ServiceName: service.ServiceName,
+		Alias:       service.Alias,
+		Version:     service.Version,
+	})
+	if err != nil {
+		return &pb.CreateServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Check service exist failed"),
+		}, err
+	}
+	if existID || exist {
+		return &pb.CreateServiceResponse{
+			Response: pb.CreateResponse(pb.ErrServiceAlreadyExists, "ServiceID conflict or found the same service."),
+		}, nil
+	}
+	insertRes, err := client.GetMongoClient().Insert(ctx, CollectionService, &Service{Domain: domain, Project: project, ServiceInfo: service})
+	if err != nil {
+		if client.IsDuplicateKey(err) {
+			return &pb.CreateServiceResponse{
+				Response: pb.CreateResponse(pb.ErrServiceAlreadyExists, "ServiceID or ServiceInfo conflict."),
+			}, nil
+		}
+		return &pb.CreateServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Register service failed."),
+		}, err
+	}
+
+	remoteIP := util.GetIPFromContext(ctx)
+	log.Infof("create micro-service[%s][%s] successfully,operator: %s", service.ServiceId, insertRes.InsertedID, remoteIP)
+
+	return &pb.CreateServiceResponse{
+		Response:  pb.CreateResponse(pb.ResponseSuccess, "Register service successfully"),
+		ServiceId: service.ServiceId,
+	}, nil
 }
 
-func (ds *DataSource) GetServices(ctx context.Context, request *pb.GetServicesRequest) (*pb.GetServicesResponse, error) {
-	return &pb.GetServicesResponse{}, nil
-}
+func (ds *DataSource) GetServices(ctx context.Context, request *pb.GetServicesRequest) (
+	*pb.GetServicesResponse, error) {
 
-func (ds *DataSource) GetService(ctx context.Context, request *pb.GetServiceRequest) (*pb.GetServiceResponse, error) {
-	return &pb.GetServiceResponse{}, nil
-}
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
 
-func (ds *DataSource) GetServiceDetail(ctx context.Context, request *pb.GetServiceRequest) (*pb.GetServiceDetailResponse, error) {
-	return &pb.GetServiceDetailResponse{}, nil
-}
+	filter := bson.M{Domain: domain, Project: project}
 
-func (ds *DataSource) GetServicesInfo(ctx context.Context, request *pb.GetServicesInfoRequest) (*pb.GetServicesInfoResponse, error) {
-	return &pb.GetServicesInfoResponse{}, nil
+	services, err := GetServices(ctx, filter)
+	if err != nil {
+		return &pb.GetServicesResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "get services data failed."),
+		}, nil
+	}
+
+	return &pb.GetServicesResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get all services successfully."),
+		Services: services,
+	}, nil
 }
 
 func (ds *DataSource) GetApplications(ctx context.Context, request *pb.GetAppsRequest) (*pb.GetAppsResponse, error) {
-	return &pb.GetAppsResponse{}, nil
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	filter := bson.M{Domain: domain, Project: project, ServiceEnv: request.Environment}
+
+	services, err := GetServices(ctx, filter)
+	if err != nil {
+		return &pb.GetAppsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "get services data failed."),
+		}, nil
+	}
+	l := len(services)
+	if l == 0 {
+		return &pb.GetAppsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "get services data failed."),
+		}, nil
+	}
+	apps := make([]string, 0, l)
+	hash := make(map[string]struct{}, l)
+	for _, svc := range services {
+		if !request.WithShared && apt.IsGlobal(pb.MicroServiceToKey(util.ParseDomainProject(ctx), svc)) {
+			continue
+		}
+		if _, ok := hash[svc.AppId]; ok {
+			continue
+		}
+		hash[svc.AppId] = struct{}{}
+		apps = append(apps, svc.AppId)
+	}
+	return &pb.GetAppsResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get all applications successfully."),
+		AppIds:   apps,
+	}, nil
+}
+
+func (ds *DataSource) GetService(ctx context.Context, request *pb.GetServiceRequest) (
+	*pb.GetServiceResponse, error) {
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		log.Errorf(err, "failed to get single service [%s] from mongo", request.ServiceId)
+		return &pb.GetServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "get service data from mongodb failed."),
+		}, err
+	}
+	if svc != nil {
+		return &pb.GetServiceResponse{
+			Response: pb.CreateResponse(pb.ResponseSuccess, "Get service successfully."),
+			Service:  svc.ServiceInfo,
+		}, nil
+	}
+	return &pb.GetServiceResponse{
+		Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service not exist."),
+	}, nil
 }
 
 func (ds *DataSource) ExistServiceByID(ctx context.Context, request *pb.GetExistenceByIDRequest) (*pb.GetExistenceByIDResponse, error) {
-	return &pb.GetExistenceByIDResponse{}, nil
+
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetExistenceByIDResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Check service exist failed."),
+			Exist:    false,
+		}, err
+	}
+
+	return &pb.GetExistenceByIDResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Check ExistService successfully."),
+		Exist:    exist,
+	}, nil
 }
 
 func (ds *DataSource) ExistService(ctx context.Context, request *pb.GetExistenceRequest) (*pb.GetExistenceResponse, error) {
-	return &pb.GetExistenceResponse{}, nil
-}
-
-func (ds *DataSource) UpdateService(ctx context.Context, request *pb.UpdateServicePropsRequest) (*pb.UpdateServicePropsResponse, error) {
-	return &pb.UpdateServicePropsResponse{}, nil
+	serviceKey := &pb.MicroServiceKey{
+		Environment: request.Environment,
+		AppId:       request.AppId,
+		ServiceName: request.ServiceName,
+		Alias:       request.ServiceName,
+		Version:     request.Version,
+	}
+	//todo add verison match.
+	services, err := GetServices(ctx, GeneratorServiceNameFilter(ctx, serviceKey))
+	if err != nil {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	if len(services) != 0 {
+		return &pb.GetExistenceResponse{
+			Response:  pb.CreateResponse(pb.ResponseSuccess, "get service id successfully."),
+			ServiceId: services[0].ServiceId,
+		}, nil
+	}
+	services, err = GetServices(ctx, GeneratorServiceAliasFilter(ctx, serviceKey))
+	if err != nil {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	if len(services) != 0 {
+		return &pb.GetExistenceResponse{
+			Response:  pb.CreateResponse(pb.ResponseSuccess, "get service id successfully."),
+			ServiceId: services[0].ServiceId,
+		}, nil
+	}
+	return &pb.GetExistenceResponse{
+		Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist"),
+	}, nil
 }
 
 func (ds *DataSource) UnregisterService(ctx context.Context, request *pb.DeleteServiceRequest) (*pb.DeleteServiceResponse, error) {
-	return &pb.DeleteServiceResponse{}, nil
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Delete service failed,failed to get service."),
+		}, err
+	}
+	if !exist {
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "Delete service failed,service not exist."),
+		}, nil
+	}
+	session, err := client.GetMongoClient().StartSession(ctx)
+	if err != nil {
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "DelService failed to create session."),
+		}, err
+	}
+	if err = session.StartTransaction(); err != nil {
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "DelService failed to start session."),
+		}, err
+	}
+	defer session.EndSession(ctx)
+	//todo delete instance,tags,schemas...
+	res, err := DelServicePri(ctx, request.ServiceId, request.Force)
+	if err != nil {
+		errAbort := session.AbortTransaction(ctx)
+		if errAbort != nil {
+			return &pb.DeleteServiceResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, "Txn delete service abort failed."),
+			}, errAbort
+		}
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Delete service failed"),
+		}, err
+	}
+	errCommit := session.CommitTransaction(ctx)
+	if errCommit != nil {
+		return &pb.DeleteServiceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Txn delete service commit failed."),
+		}, errCommit
+	}
+	return &pb.DeleteServiceResponse{
+		Response: res,
+	}, nil
 }
 
-func (ds *DataSource) GetDeleteServiceFunc(ctx context.Context, serviceID string, force bool, serviceRespChan chan<- *pb.DelServicesRspInfo) func(context.Context) {
-	return func(_ context.Context) {
-
+func DelServicePri(ctx context.Context, serviceID string, force bool) (*pb.Response, error) {
+	remoteIP := util.GetIPFromContext(ctx)
+	title := "delete"
+	if force {
+		title = "force delete"
 	}
+
+	if serviceID == apt.Service.ServiceId {
+		err := errors.New("not allow to delete service center")
+		log.Errorf(err, "%s micro-service[%s] failed, operator: %s", title, serviceID, remoteIP)
+		return pb.CreateResponse(pb.ErrInvalidParams, err.Error()), nil
+	}
+	microservice, err := GetService(ctx, GeneratorServiceFilter(ctx, serviceID))
+	if err != nil {
+		log.Errorf(err, "%s micro-service[%s] failed, get service file failed, operator: %s",
+			title, serviceID, remoteIP)
+		return pb.CreateResponse(pb.ErrInternal, err.Error()), err
+	}
+	if microservice == nil {
+		log.Errorf(err, "%s micro-service[%s] failed, service does not exist, operator: %s",
+			title, serviceID, remoteIP)
+		return pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist."), nil
+	}
+	// 强制删除，则与该服务相关的信息删除，非强制删除： 如果作为该被依赖（作为provider，提供服务,且不是只存在自依赖）或者存在实例，则不能删除
+	if !force {
+		log.Infof("force delete,should del instance...")
+		//todo wait for dep interface
+	}
+	filter := GeneratorServiceFilter(ctx, serviceID)
+	//todo del instances
+	tables := []string{CollectionService, CollectionSchema, CollectionRule}
+	for _, col := range tables {
+		err := client.GetMongoClient().DocDeleteMany(ctx, col, filter)
+		if err != nil {
+			return pb.CreateResponse(pb.ErrInternal, err.Error()), err
+		}
+	}
+	return pb.CreateResponse(pb.ResponseSuccess, "Unregister service successfully."), nil
+
+}
+
+func (ds *DataSource) UpdateService(ctx context.Context, request *pb.UpdateServicePropsRequest) (
+	*pb.UpdateServicePropsResponse, error) {
+
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.UpdateServicePropsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "UpdateService failed,failed to get service."),
+		}, err
+	}
+	if !exist {
+		return &pb.UpdateServicePropsResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "UpdateService failed,service not exist."),
+		}, nil
+	}
+
+	err = UpdateService(ctx, GeneratorServiceFilter(ctx, request.ServiceId), bson.M{"$set": bson.M{ServiceModTime: strconv.FormatInt(time.Now().Unix(), 10), ServiceProperty: request.Properties}})
+	if err != nil {
+		log.Errorf(err, "update service [%s] properties failed, update mongo failed", request.ServiceId)
+		return &pb.UpdateServicePropsResponse{
+			Response: pb.CreateResponse(pb.ErrUnavailableBackend, "Update doc in mongo failed."),
+		}, nil
+	}
+	return &pb.UpdateServicePropsResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Update service successfully."),
+	}, nil
+}
+
+func (ds *DataSource) GetDeleteServiceFunc(ctx context.Context, serviceID string, force bool,
+	serviceRespChan chan<- *pb.DelServicesRspInfo) func(context.Context) {
+	return func(_ context.Context) {}
+}
+
+func (ds *DataSource) GetServiceDetail(ctx context.Context, request *pb.GetServiceRequest) (
+	*pb.GetServiceDetailResponse, error) {
+	mgSvc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		return &pb.GetServiceDetailResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	if mgSvc == nil {
+		return &pb.GetServiceDetailResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist."),
+		}, nil
+	}
+	svc := mgSvc.ServiceInfo
+	versions, err := GetServicesVersions(ctx, bson.M{})
+	if err != nil {
+		log.Errorf(err, "get service[%s/%s/%s] all versions failed",
+			svc.Environment, svc.AppId, svc.ServiceName)
+		return &pb.GetServiceDetailResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	options := []string{"tags", "rules", "instances", "schemas", "dependencies"}
+	serviceInfo, err := getServiceDetailUtil(ctx, mgSvc, false, options)
+	if err != nil {
+		return &pb.GetServiceDetailResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	serviceInfo.MicroService = svc
+	serviceInfo.MicroServiceVersions = versions
+	return &pb.GetServiceDetailResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get service successfully"),
+		Service:  serviceInfo,
+	}, nil
+
+}
+
+func (ds *DataSource) GetServicesInfo(ctx context.Context, request *pb.GetServicesInfoRequest) (
+	*pb.GetServicesInfoResponse, error) {
+	optionMap := make(map[string]struct{}, len(request.Options))
+	for _, opt := range request.Options {
+		optionMap[opt] = struct{}{}
+	}
+
+	options := make([]string, 0, len(optionMap))
+	if _, ok := optionMap["all"]; ok {
+		optionMap["statistics"] = struct{}{}
+		options = []string{"tags", "rules", "instances", "schemas", "dependencies"}
+	} else {
+		for opt := range optionMap {
+			options = append(options, opt)
+		}
+	}
+	//todo add get statistics info
+	services, err := GetMongoServices(ctx, bson.M{})
+	if err != nil {
+		log.Errorf(err, "get all services by domain failed")
+		return &pb.GetServicesInfoResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	allServiceDetails := make([]*pb.ServiceDetail, 0, len(services))
+	domainProject := util.ParseDomainProject(ctx)
+	for _, mgSvc := range services {
+		if !request.WithShared && apt.IsGlobal(pb.MicroServiceToKey(domainProject, mgSvc.ServiceInfo)) {
+			continue
+		}
+		if len(request.AppId) > 0 {
+			if request.AppId != mgSvc.ServiceInfo.AppId {
+				continue
+			}
+			if len(request.ServiceName) > 0 && request.ServiceName != mgSvc.ServiceInfo.ServiceName {
+				continue
+			}
+		}
+
+		serviceDetail, err := getServiceDetailUtil(ctx, mgSvc, request.CountOnly, options)
+		if err != nil {
+			return &pb.GetServicesInfoResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+			}, err
+		}
+		serviceDetail.MicroService = mgSvc.ServiceInfo
+		allServiceDetails = append(allServiceDetails, serviceDetail)
+	}
+
+	return &pb.GetServicesInfoResponse{
+		Response:          pb.CreateResponse(pb.ResponseSuccess, "Get services info successfully."),
+		AllServicesDetail: allServiceDetails,
+		Statistics:        nil,
+	}, nil
+}
+
+func (ds *DataSource) AddTags(ctx context.Context, request *pb.AddServiceTagsRequest) (*pb.AddServiceTagsResponse, error) {
+	service, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		log.Errorf(err, "failed to add tags for service [%s] for get service failed,", request.ServiceId)
+		return &pb.AddServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Failed to check service exist"),
+		}, nil
+	}
+	if service == nil {
+		return &pb.AddServiceTagsResponse{Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service not exist")}, nil
+	}
+	//todo add quto check
+	dataTags := service.Tags
+	tags := request.Tags
+	for key, value := range dataTags {
+		if _, ok := tags[key]; ok {
+			continue
+		}
+		tags[key] = value
+	}
+	err = UpdateService(ctx, GeneratorServiceFilter(ctx, request.ServiceId), bson.M{"$set": bson.M{ServiceTag: tags}})
+	if err != nil {
+		log.Errorf(err, "update service [%s] tags failed.", request.ServiceId)
+		return &pb.AddServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	return &pb.AddServiceTagsResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Add service tags successfully."),
+	}, nil
+}
+
+func (ds *DataSource) GetTags(ctx context.Context, request *pb.GetServiceTagsRequest) (*pb.GetServiceTagsResponse, error) {
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		log.Errorf(err, "failed to get service [%s] tags", request.ServiceId)
+		return &pb.GetServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	if svc == nil {
+		return &pb.GetServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist"),
+		}, nil
+	}
+	return &pb.GetServiceTagsResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get service tags successfully."),
+		Tags:     svc.Tags,
+	}, nil
+}
+
+func (ds *DataSource) UpdateTag(ctx context.Context, request *pb.UpdateServiceTagRequest) (*pb.UpdateServiceTagResponse, error) {
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		log.Errorf(err, "failed to get service [%s] tags", request.ServiceId)
+		return &pb.UpdateServiceTagResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	if svc == nil {
+		return &pb.UpdateServiceTagResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist"),
+		}, nil
+	}
+	dataTags := svc.Tags
+	if len(dataTags) > 0 {
+		if _, ok := dataTags[request.Key]; !ok {
+			return &pb.UpdateServiceTagResponse{
+				Response: pb.CreateResponse(pb.ErrTagNotExists, "Tag does not exist"),
+			}, nil
+		}
+	}
+	newTags := make(map[string]string, len(dataTags))
+	for k, v := range dataTags {
+		newTags[k] = v
+	}
+	newTags[request.Key] = request.Value
+
+	err = UpdateService(ctx, GeneratorServiceFilter(ctx, request.ServiceId), bson.M{"$set": bson.M{ServiceTag: newTags}})
+	if err != nil {
+		log.Errorf(err, "update service [%s] tags failed.", request.ServiceId)
+		return &pb.UpdateServiceTagResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	return &pb.UpdateServiceTagResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Update service tag success."),
+	}, nil
+}
+
+func (ds *DataSource) DeleteTags(ctx context.Context, request *pb.DeleteServiceTagsRequest) (*pb.DeleteServiceTagsResponse, error) {
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		log.Errorf(err, "failed to get service [%s] tags", request.ServiceId)
+		return &pb.DeleteServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	if svc == nil {
+		return &pb.DeleteServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist"),
+		}, nil
+	}
+	dataTags := svc.Tags
+	newTags := make(map[string]string, len(dataTags))
+	for k, v := range dataTags {
+		newTags[k] = v
+	}
+	if len(dataTags) > 0 {
+		for _, key := range request.Keys {
+			if _, ok := dataTags[key]; !ok {
+				return &pb.DeleteServiceTagsResponse{
+					Response: pb.CreateResponse(pb.ErrTagNotExists, "Tag does not exist"),
+				}, nil
+			}
+			delete(newTags, key)
+		}
+	}
+	err = UpdateService(ctx, GeneratorServiceFilter(ctx, request.ServiceId), bson.M{"$set": bson.M{ServiceTag: newTags}})
+	if err != nil {
+		log.Errorf(err, "delete service [%s] tags failed.", request.ServiceId)
+		return &pb.DeleteServiceTagsResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	return &pb.DeleteServiceTagsResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Update service tag success."),
+	}, nil
+}
+
+func (ds *DataSource) GetSchema(ctx context.Context, request *pb.GetSchemaRequest) (*pb.GetSchemaResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "GetSchema failed to check service exist."),
+		}, nil
+	}
+	if !exist {
+		return &pb.GetSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "GetSchema service does not exist."),
+		}, nil
+	}
+	Schema, err := GetSchema(ctx, GeneratorSchemaFilter(ctx, request.ServiceId, request.SchemaId))
+	if err != nil {
+		return &pb.GetSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "GetSchema failed from mongodb."),
+		}, nil
+	}
+	return &pb.GetSchemaResponse{
+		Response:      pb.CreateResponse(pb.ResponseSuccess, "Get schema info successfully."),
+		Schema:        Schema.SchemaInfo,
+		SchemaSummary: Schema.SchemaSummary,
+	}, nil
+}
+
+func (ds *DataSource) GetAllSchemas(ctx context.Context, request *pb.GetAllSchemaRequest) (*pb.GetAllSchemaResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetAllSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "GetAllSchemas failed for get service failed"),
+		}, nil
+	}
+	if !exist {
+		return &pb.GetAllSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "GetAllSchemas failed for service not exist"),
+		}, nil
+	}
+
+	schemas, err := GetSchemas(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		return &pb.GetAllSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "GetAllSchemas failed for get schemas failed"),
+		}, nil
+	}
+	return &pb.GetAllSchemaResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get all schema info successfully."),
+		Schemas:  schemas,
+	}, nil
+}
+
+func (ds *DataSource) ExistSchema(ctx context.Context, request *pb.GetExistenceRequest) (*pb.GetExistenceResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "ExistSchema failed for get service failed"),
+		}, nil
+	}
+	if !exist {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "ExistSchema failed for service not exist"),
+		}, nil
+	}
+	Schema, err := GetSchema(ctx, GeneratorSchemaFilter(ctx, request.ServiceId, request.SchemaId))
+	if err != nil {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "ExistSchema failed for get schema failed."),
+		}, nil
+	}
+	if Schema == nil {
+		return &pb.GetExistenceResponse{
+			Response: pb.CreateResponse(pb.ErrSchemaNotExists, "ExistSchema failed for schema not exist."),
+		}, nil
+	}
+	return &pb.GetExistenceResponse{
+		Response:  pb.CreateResponse(pb.ResponseSuccess, "Schema exist."),
+		Summary:   Schema.SchemaSummary,
+		SchemaId:  Schema.SchemaID,
+		ServiceId: Schema.ServiceID,
+	}, nil
+}
+
+func (ds *DataSource) DeleteSchema(ctx context.Context, request *pb.DeleteSchemaRequest) (*pb.DeleteSchemaResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.DeleteSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "DeleteSchema failed for get service failed."),
+		}, nil
+	}
+	if !exist {
+		return &pb.DeleteSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "DeleteSchema failed for service not exist."),
+		}, nil
+	}
+	filter := GeneratorSchemaFilter(ctx, request.ServiceId, request.SchemaId)
+	_, err = client.GetMongoClient().Delete(ctx, CollectionSchema, filter)
+	if err != nil {
+		return &pb.DeleteSchemaResponse{
+			Response: pb.CreateResponse(pb.ErrUnavailableBackend, "DeleteSchema failed for delete schema failed."),
+		}, nil
+	}
+	return &pb.DeleteSchemaResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Delete schema info successfully."),
+	}, nil
+}
+
+func (ds *DataSource) ModifySchema(ctx context.Context, request *pb.ModifySchemaRequest) (*pb.ModifySchemaResponse, error) {
+	remoteIP := util.GetIPFromContext(ctx)
+	serviceID := request.ServiceId
+	schemaID := request.SchemaId
+	schema := pb.Schema{
+		SchemaId: request.SchemaId,
+		Summary:  request.Summary,
+		Schema:   request.Schema,
+	}
+	session, err := client.GetMongoClient().StartSession(ctx)
+	if err != nil {
+		return &pb.ModifySchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "ModifySchema failed to create session."),
+		}, err
+	}
+	if err = session.StartTransaction(); err != nil {
+		return &pb.ModifySchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "ModifySchema failed to start session."),
+		}, err
+	}
+	defer session.EndSession(ctx)
+	err = ds.modifySchema(ctx, request.ServiceId, &schema)
+	if err != nil {
+		log.Errorf(err, "modify schema[%s/%s] failed, operator: %s", serviceID, schemaID, remoteIP)
+		errAbort := session.AbortTransaction(ctx)
+		if errAbort != nil {
+			return &pb.ModifySchemaResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, "Txn ModifySchema Abort failed."),
+			}, errAbort
+		}
+		return &pb.ModifySchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Txn ModifySchema failed."),
+		}, err
+	}
+	err = session.CommitTransaction(ctx)
+	if err != nil {
+		return &pb.ModifySchemaResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Txn ModifySchema CommitTransaction failed."),
+		}, err
+	}
+	log.Infof("modify schema[%s/%s] successfully, operator: %s", serviceID, schemaID, remoteIP)
+	return &pb.ModifySchemaResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "modify schema info success."),
+	}, nil
+}
+
+func (ds *DataSource) ModifySchemas(ctx context.Context, request *pb.ModifySchemasRequest) (*pb.ModifySchemasResponse, error) {
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, request.ServiceId))
+	if err != nil {
+		return &pb.ModifySchemasResponse{Response: pb.CreateResponse(pb.ErrInternal, err.Error())}, err
+	}
+	if svc == nil {
+		return &pb.ModifySchemasResponse{Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service not exist")}, nil
+	}
+	session, err := client.GetMongoClient().StartSession(ctx)
+	if err != nil {
+		return &pb.ModifySchemasResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "ModifySchemas failed to start session"),
+		}, err
+	}
+	if err = session.StartTransaction(); err != nil {
+		return &pb.ModifySchemasResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "ModifySchemas failed to start session"),
+		}, err
+	}
+	defer session.EndSession(ctx)
+	err = ds.modifySchemas(ctx, svc.ServiceInfo, request.Schemas)
+	if err != nil {
+		errAbort := session.AbortTransaction(ctx)
+		if errAbort != nil {
+			return &pb.ModifySchemasResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, "Txn ModifySchemas Abort failed."),
+			}, errAbort
+		}
+		return &pb.ModifySchemasResponse{Response: pb.CreateResponse(pb.ErrInternal, err.Error())}, err
+	}
+	err = session.CommitTransaction(ctx)
+	if err != nil {
+		return &pb.ModifySchemasResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Txn ModifySchemas CommitTransaction failed."),
+		}, err
+	}
+	return &pb.ModifySchemasResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "modify schemas info success"),
+	}, nil
+
+}
+
+func (ds *DataSource) modifySchema(ctx context.Context, serviceID string, schema *pb.Schema) *pb.Error {
+	remoteIP := util.GetIPFromContext(ctx)
+	svc, err := GetService(ctx, GeneratorServiceFilter(ctx, serviceID))
+	if err != nil {
+		return pb.NewError(pb.ErrInternal, err.Error())
+	}
+	if svc == nil {
+		return pb.NewError(pb.ErrServiceNotExists, "Service does not exist.")
+	}
+	microservice := svc.ServiceInfo
+	var isExist bool
+	for _, sid := range microservice.Schemas {
+		if sid == schema.SchemaId {
+			isExist = true
+			break
+		}
+	}
+	var newSchemas []string
+	if !ds.isSchemaEditable(microservice) {
+		if len(microservice.Schemas) != 0 && !isExist {
+			return pb.NewError(pb.ErrUndefinedSchemaID, "Non-existent schemaID can't be added request "+pb.ENV_PROD)
+		}
+		respSchema, err := GetSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId))
+		if err != nil {
+			return pb.NewError(pb.ErrUnavailableBackend, err.Error())
+		}
+		if schema != nil {
+			if len(schema.Summary) == 0 {
+				log.Errorf(err, "modify schema[%s/%s] failed, get schema summary failed, operator: %s",
+					serviceID, schema.SchemaId, remoteIP)
+				return pb.NewError(pb.ErrUnavailableBackend, err.Error())
+			}
+			if len(respSchema.SchemaSummary) != 0 {
+				log.Errorf(err, "%s mode, schema[%s/%s] already exist, can not be changed, operator: %s",
+					pb.ENV_PROD, serviceID, schema.SchemaId, remoteIP)
+				return pb.NewError(pb.ErrModifySchemaNotAllow, "schema already exist, can not be changed request "+pb.ENV_PROD)
+			}
+		}
+		if len(microservice.Schemas) == 0 {
+			copy(newSchemas, microservice.Schemas)
+			newSchemas = append(newSchemas, schema.SchemaId)
+		}
+	} else {
+		if !isExist {
+			copy(newSchemas, microservice.Schemas)
+			newSchemas = append(newSchemas, schema.SchemaId)
+		}
+	}
+	if len(newSchemas) != len(microservice.Schemas) {
+		err := UpdateService(ctx, GeneratorServiceFilter(ctx, serviceID), bson.M{"$set": bson.M{ServiceSchemas: newSchemas}})
+		if err != nil {
+			return pb.NewError(pb.ErrInternal, err.Error())
+		}
+	}
+	newSchema := bson.M{"$set": bson.M{SchemaInfo: schema.Schema, SchemaSummary: schema.Summary}}
+	err = UpdateSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId), newSchema, options.FindOneAndUpdate().SetUpsert(true))
+	if err != nil {
+		return pb.NewError(pb.ErrInternal, err.Error())
+	}
+	return nil
+}
+
+func (ds *DataSource) modifySchemas(ctx context.Context, service *pb.MicroService, schemas []*pb.Schema) *pb.Error {
+	remoteIP := util.GetIPFromContext(ctx)
+	serviceID := service.ServiceId
+	schemasFromDatabase, err := GetSchemas(ctx, GeneratorServiceFilter(ctx, serviceID))
+	if err != nil {
+		log.Errorf(nil, "modify service[%s] schemas failed, get schemas failed, operator: %s",
+			serviceID, remoteIP)
+		return pb.NewError(pb.ErrUnavailableBackend, err.Error())
+	}
+	needUpdateSchemas, needAddSchemas, needDeleteSchemas, nonExistSchemaIds :=
+		datasource.SchemasAnalysis(schemas, schemasFromDatabase, service.Schemas)
+	if !ds.isSchemaEditable(service) {
+		if len(service.Schemas) == 0 {
+			//todo add quota check
+			err := UpdateService(ctx, GeneratorServiceFilter(ctx, serviceID), bson.M{"$set": bson.M{ServiceSchemas: nonExistSchemaIds}})
+			if err != nil {
+				log.Errorf(err, "modify service[%s] schemas failed, update service.Schemas failed, operator: %s",
+					serviceID, remoteIP)
+				return pb.NewError(pb.ErrInternal, err.Error())
+			}
+		} else {
+			if len(nonExistSchemaIds) != 0 {
+				errInfo := fmt.Errorf("non-existent schemaIDs %v", nonExistSchemaIds)
+				log.Errorf(errInfo, "modify service[%s] schemas failed, operator: %s", serviceID, remoteIP)
+				return pb.NewError(pb.ErrUndefinedSchemaID, errInfo.Error())
+			}
+			for _, needUpdateSchema := range needUpdateSchemas {
+				exist, err := SchemaExist(ctx, serviceID, needUpdateSchema.SchemaId)
+				if err != nil {
+					return pb.NewError(pb.ErrInternal, err.Error())
+				}
+				if !exist {
+					err := UpdateSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, needUpdateSchema.SchemaId), bson.M{"$set": bson.M{SchemaInfo: needUpdateSchema.Schema, SchemaSummary: needUpdateSchema.Summary}}, options.FindOneAndUpdate().SetUpsert(true))
+					if err != nil {
+						return pb.NewError(pb.ErrInternal, err.Error())
+					}
+				} else {
+					log.Warnf("schema[%s/%s] and it's summary already exist, skip to update, operator: %s",
+						serviceID, needUpdateSchema.SchemaId, remoteIP)
+				}
+			}
+		}
+
+		for _, schema := range needAddSchemas {
+			log.Infof("add new schema[%s/%s], operator: %s", serviceID, schema.SchemaId, remoteIP)
+			err := UpdateSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId), bson.M{"$set": bson.M{SchemaInfo: schema.Schema, SchemaSummary: schema.Summary}}, options.FindOneAndUpdate().SetUpsert(true))
+			if err != nil {
+				return pb.NewError(pb.ErrInternal, err.Error())
+			}
+		}
+	} else {
+
+		var schemaIDs []string
+		for _, schema := range needAddSchemas {
+			log.Infof("add new schema[%s/%s], operator: %s", serviceID, schema.SchemaId, remoteIP)
+			err := UpdateSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId), bson.M{"$set": bson.M{SchemaInfo: schema.Schema, SchemaSummary: schema.Summary}}, options.FindOneAndUpdate().SetUpsert(true))
+			if err != nil {
+				return pb.NewError(pb.ErrInternal, err.Error())
+			}
+			schemaIDs = append(schemaIDs, schema.SchemaId)
+		}
+
+		for _, schema := range needUpdateSchemas {
+			log.Infof("update schema[%s/%s], operator: %s", serviceID, schema.SchemaId, remoteIP)
+			err := UpdateSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId), bson.M{"$set": bson.M{SchemaInfo: schema.Schema, SchemaSummary: schema.Summary}}, options.FindOneAndUpdate().SetUpsert(true))
+			if err != nil {
+				return pb.NewError(pb.ErrInternal, err.Error())
+			}
+			schemaIDs = append(schemaIDs, schema.SchemaId)
+		}
+
+		for _, schema := range needDeleteSchemas {
+			log.Infof("delete non-existent schema[%s/%s], operator: %s", serviceID, schema.SchemaId, remoteIP)
+			err = DeleteSchema(ctx, GeneratorSchemaFilter(ctx, serviceID, schema.SchemaId))
+			if err != nil {
+				return pb.NewError(pb.ErrInternal, err.Error())
+			}
+		}
+
+		err := UpdateService(ctx, GeneratorServiceFilter(ctx, serviceID), bson.M{"$set": bson.M{ServiceSchemas: schemaIDs}})
+		if err != nil {
+			log.Errorf(err, "modify service[%s] schemas failed, update service.Schemas failed, operator: %s",
+				serviceID, remoteIP)
+			return pb.NewError(pb.ErrInternal, err.Error())
+		}
+	}
+	return nil
+}
+
+func (ds *DataSource) AddRule(ctx context.Context, request *pb.AddServiceRulesRequest) (*pb.AddServiceRulesResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		log.Errorf(err, "failed to add rules for service [%s] for get service failed,", request.ServiceId)
+		return &pb.AddServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Failed to check service exist"),
+		}, nil
+	}
+	if !exist {
+		return &pb.AddServiceRulesResponse{Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service does not exist")}, nil
+	}
+	//todo add quota check
+	rules, err := GetRules(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.AddServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	var ruleType string
+	if len(rules) != 0 {
+		ruleType = rules[0].RuleType
+	}
+	ruleIDs := make([]string, 0, len(request.Rules))
+	for _, rule := range request.Rules {
+		if len(ruleType) == 0 {
+			ruleType = rule.RuleType
+		} else if ruleType != rule.RuleType {
+			return &pb.AddServiceRulesResponse{
+				Response: pb.CreateResponse(pb.ErrBlackAndWhiteRule, "Service can only contain one rule type,Black or white."),
+			}, nil
+		}
+		//the rule unique index is (serviceid,attribute,pattern)
+		exist, err := RuleExist(ctx, GeneratorRuleAttFilter(ctx, request.ServiceId, rule.Attribute, rule.Pattern))
+		if err != nil {
+			return &pb.AddServiceRulesResponse{
+				Response: pb.CreateResponse(pb.ErrUnavailableBackend, "Can not check rule if exist."),
+			}, nil
+		}
+		if exist {
+			continue
+		}
+		timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+		ruleAdd := &Rule{
+			Domain:    util.ParseDomain(ctx),
+			Project:   util.ParseProject(ctx),
+			ServiceID: request.ServiceId,
+			RuleInfo: &pb.ServiceRule{
+				RuleId:       util.GenerateUUID(),
+				RuleType:     rule.RuleType,
+				Attribute:    rule.Attribute,
+				Pattern:      rule.Pattern,
+				Description:  rule.Description,
+				Timestamp:    timestamp,
+				ModTimestamp: timestamp,
+			},
+		}
+		ruleIDs = append(ruleIDs, ruleAdd.RuleInfo.RuleId)
+		_, err = client.GetMongoClient().Insert(ctx, CollectionRule, ruleAdd)
+		if err != nil {
+			return &pb.AddServiceRulesResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+			}, err
+		}
+	}
+	return &pb.AddServiceRulesResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Add service rules successfully."),
+		RuleIds:  ruleIDs,
+	}, nil
+}
+
+func (ds *DataSource) GetRules(ctx context.Context, request *pb.GetServiceRulesRequest) (
+	*pb.GetServiceRulesResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "GetRules failed for get service failed."),
+		}, nil
+	}
+	if !exist {
+		return &pb.GetServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "GetRules failed for service not exist."),
+		}, nil
+	}
+	rules, err := GetRules(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.GetServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	return &pb.GetServiceRulesResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Get service rules successfully."),
+		Rules:    rules,
+	}, nil
+}
+
+func (ds *DataSource) DeleteRule(ctx context.Context, request *pb.DeleteServiceRulesRequest) (
+	*pb.DeleteServiceRulesResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		log.Errorf(err, "failed to add tags for service [%s] for get service failed,", request.ServiceId)
+		return &pb.DeleteServiceRulesResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, "Failed to check service exist"),
+		}, err
+	}
+	if !exist {
+		return &pb.DeleteServiceRulesResponse{Response: pb.CreateResponse(pb.ErrServiceNotExists, "Service not exist")}, nil
+	}
+	for _, ruleID := range request.RuleIds {
+		exist, err := RuleExist(ctx, GeneratorRuleFilter(ctx, request.ServiceId, ruleID))
+		if err != nil {
+			return &pb.DeleteServiceRulesResponse{
+				Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+			}, nil
+		}
+		if !exist {
+			return &pb.DeleteServiceRulesResponse{
+				Response: pb.CreateResponse(pb.ErrRuleNotExists, "This rule does not exist."),
+			}, nil
+		}
+	}
+
+	return &pb.DeleteServiceRulesResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Delete service rules successfully."),
+	}, nil
+}
+
+func (ds *DataSource) UpdateRule(ctx context.Context, request *pb.UpdateServiceRuleRequest) (
+	*pb.UpdateServiceRuleResponse, error) {
+	exist, err := ServiceExistID(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "UpdateRule failed for get service failed."),
+			//Schemas:  nil,
+		}, nil
+	}
+	if !exist {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrServiceNotExists, "UpdateRule failed for service not exist."),
+		}, nil
+	}
+	rules, err := GetRules(ctx, request.ServiceId)
+	if err != nil {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrUnavailableBackend, "UpdateRule failed for get rule."),
+		}, nil
+	}
+	if len(rules) >= 1 && rules[0].RuleType != request.Rule.RuleType {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrModifyRuleNotAllow, "Exist multiple rules, can not change rule type. Rule type is ."+rules[0].RuleType),
+		}, nil
+	}
+	exist, err = RuleExist(ctx, GeneratorRuleFilter(ctx, request.ServiceId, request.RuleId))
+	if err != nil {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, nil
+	}
+	if !exist {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrRuleNotExists, "This rule does not exist."),
+		}, nil
+	}
+
+	newRule := bson.M{"$set": bson.M{RuleRuletype: request.Rule.RuleType,
+		RulePattern: request.Rule.Pattern, RuleAttribute: request.Rule.Attribute,
+		RuleDescription: request.Rule.Description,
+		RuleModTime:     strconv.FormatInt(time.Now().Unix(), 10)}}
+
+	err = UpdateRule(ctx, GeneratorRuleFilter(ctx, request.ServiceId, request.RuleId), newRule)
+	if err != nil {
+		return &pb.UpdateServiceRuleResponse{
+			Response: pb.CreateResponse(pb.ErrInternal, err.Error()),
+		}, err
+	}
+	return &pb.UpdateServiceRuleResponse{
+		Response: pb.CreateResponse(pb.ResponseSuccess, "Update service rules succesfully."),
+	}, nil
+}
+
+func (ds *DataSource) isSchemaEditable(service *pb.MicroService) bool {
+	return (len(service.Environment) != 0 && service.Environment != pb.ENV_PROD) || ds.SchemaEditable
+}
+
+func ServiceExist(ctx context.Context, service *pb.MicroServiceKey) (bool, error) {
+	filter := GeneratorServiceNameFilter(ctx, service)
+	return client.GetMongoClient().DocExist(ctx, CollectionService, filter)
+}
+
+func ServiceExistID(ctx context.Context, serviceID string) (bool, error) {
+	filter := GeneratorServiceFilter(ctx, serviceID)
+	return client.GetMongoClient().DocExist(ctx, CollectionService, filter)
+}
+
+func GetService(ctx context.Context, filter bson.M) (*Service, error) {
+	findRes, err := client.GetMongoClient().FindOne(ctx, CollectionService, filter)
+	if err != nil {
+		return nil, err
+	}
+	var svc *Service
+	if findRes.Err() != nil {
+		//not get any service,not db err
+		return nil, nil
+	}
+	err = findRes.Decode(&svc)
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func GetServices(ctx context.Context, filter bson.M) ([]*pb.MicroService, error) {
+	res, err := client.GetMongoClient().Find(ctx, CollectionService, filter)
+	if err != nil {
+		return nil, err
+	}
+	var services []*pb.MicroService
+	for res.Next(ctx) {
+		var tmp Service
+		err := res.Decode(&tmp)
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, tmp.ServiceInfo)
+	}
+	return services, nil
+}
+
+func GetMongoServices(ctx context.Context, filter bson.M) ([]*Service, error) {
+	res, err := client.GetMongoClient().Find(ctx, CollectionService, filter)
+	if err != nil {
+		return nil, err
+	}
+	var services []*Service
+	for res.Next(ctx) {
+		var tmp *Service
+		err := res.Decode(&tmp)
+		if err != nil {
+			return nil, err
+		}
+		services = append(services, tmp)
+	}
+	return services, nil
+}
+
+func GetServicesVersions(ctx context.Context, filter interface{}) ([]string, error) {
+	res, err := client.GetMongoClient().Find(ctx, CollectionService, filter)
+	if err != nil {
+		return nil, nil
+	}
+	var versions []string
+	for res.Next(ctx) {
+		var tmp string
+		err := res.Decode(&tmp)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, tmp)
+	}
+	return versions, nil
+}
+
+func getServiceDetailUtil(ctx context.Context, mgs *Service, countOnly bool, options []string) (*pb.ServiceDetail, error) {
+	serviceDetail := new(pb.ServiceDetail)
+	if countOnly {
+		serviceDetail.Statics = new(pb.Statistics)
+	}
+	for _, opt := range options {
+		expr := opt
+		switch expr {
+		case "tags":
+			serviceDetail.Tags = mgs.Tags
+		case "rules":
+			rules, err := GetRules(ctx, mgs.ServiceInfo.ServiceId)
+			if err != nil {
+				log.Errorf(err, "get service[%s]'s all rules failed", mgs.ServiceInfo.ServiceId)
+				return nil, err
+			}
+			for _, rule := range rules {
+				rule.Timestamp = rule.ModTimestamp
+			}
+			serviceDetail.Rules = rules
+		case "instances":
+			//todo wait instance interface
+		case "schemas":
+			schemas, err := GetSchemas(ctx, GeneratorServiceFilter(ctx, mgs.ServiceInfo.ServiceId))
+			if err != nil {
+				log.Errorf(err, "get service[%s]'s all schemas failed", mgs.ServiceInfo.ServiceId)
+				return nil, err
+			}
+			serviceDetail.SchemaInfos = schemas
+		case "dependencies":
+			//todo wait dependencied interface
+		case "":
+			continue
+		default:
+			log.Errorf(nil, "request option[%s] is invalid", opt)
+		}
+	}
+	return serviceDetail, nil
+}
+
+func UpdateService(ctx context.Context, filter interface{}, m bson.M) error {
+	return client.GetMongoClient().DocUpdate(ctx, CollectionService, filter, m)
+}
+
+func GetRules(ctx context.Context, serviceID string) ([]*pb.ServiceRule, error) {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	filter := bson.M{Domain: domain, Project: project, RuleServiceID: serviceID}
+
+	ruleRes, err := client.GetMongoClient().Find(ctx, CollectionRule, filter)
+	if err != nil {
+		return nil, err
+	}
+	var rules []*pb.ServiceRule
+	for ruleRes.Next(ctx) {
+		var tmpRule *Rule
+		err := ruleRes.Decode(&tmpRule)
+		if err != nil {
+			return nil, err
+		}
+		rules = append(rules, tmpRule.RuleInfo)
+	}
+	return rules, nil
+}
+
+func UpdateRule(ctx context.Context, filter interface{}, m bson.M) error {
+	return client.GetMongoClient().DocUpdate(ctx, CollectionRule, filter, m)
+}
+
+func UpdateSchema(ctx context.Context, filter interface{}, m bson.M, opts ...*options.FindOneAndUpdateOptions) error {
+	return client.GetMongoClient().DocUpdate(ctx, CollectionSchema, filter, m, opts...)
+}
+
+func DeleteSchema(ctx context.Context, filter interface{}) error {
+	res, err := client.GetMongoClient().DocDelete(ctx, CollectionSchema, filter)
+	if err != nil {
+		return err
+	}
+	if !res {
+		return errors.New("delete schema failed")
+	}
+	return nil
+}
+
+func RuleExist(ctx context.Context, filter bson.M) (bool, error) {
+	return client.GetMongoClient().DocExist(ctx, CollectionRule, filter)
+}
+
+func GeneratorServiceFilter(ctx context.Context, serviceID string) bson.M {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	return bson.M{Domain: domain, Project: project, ServiceServiceID: serviceID}
+}
+
+func GeneratorServiceNameFilter(ctx context.Context, service *pb.MicroServiceKey) bson.M {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	return bson.M{Domain: domain, Project: project, ServiceEnv: service.Environment, ServiceAppID: service.AppId, ServiceServiceName: service.ServiceName, ServiceVersion: service.Version}
+}
+
+func GeneratorServiceAliasFilter(ctx context.Context, service *pb.MicroServiceKey) bson.M {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	return bson.M{Domain: domain, Project: project, ServiceEnv: service.Environment, ServiceAppID: service.AppId, ServiceAlias: service.Alias, ServiceVersion: service.Version}
+}
+
+func GeneratorRuleAttFilter(ctx context.Context, serviceID, attribute, pattern string) bson.M {
+	return bson.M{RuleServiceID: serviceID, RuleAttribute: attribute, RulePattern: pattern}
+}
+
+func GeneratorSchemaFilter(ctx context.Context, serviceID, schemaID string) bson.M {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	return bson.M{Domain: domain, Project: project, SchemaServiceID: serviceID, SchemaID: schemaID}
+}
+
+func GeneratorRuleFilter(ctx context.Context, serviceID, ruleID string) bson.M {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+
+	return bson.M{Domain: domain, Project: project, RuleServiceID: serviceID, RuleRuleID: ruleID}
+}
+
+func GetSchemas(ctx context.Context, filter bson.M) ([]*pb.Schema, error) {
+	getRes, err := client.GetMongoClient().Find(ctx, CollectionSchema, filter)
+	if err != nil {
+		return nil, err
+	}
+	var schemas []*pb.Schema
+	for getRes.Next(ctx) {
+		var tmp *Schema
+		err = getRes.Decode(&tmp)
+		if err != nil {
+			return nil, err
+		}
+		schemas = append(schemas, &pb.Schema{
+			SchemaId: tmp.SchemaID,
+			Summary:  tmp.SchemaSummary,
+			Schema:   tmp.SchemaInfo,
+		})
+	}
+	return schemas, nil
+}
+
+func GetSchema(ctx context.Context, filter bson.M) (*Schema, error) {
+	findRes, err := client.GetMongoClient().FindOne(ctx, CollectionSchema, filter)
+	if err != nil {
+		return nil, err
+	}
+	var schema *Schema
+	err = findRes.Decode(&schema)
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+func SchemaExist(ctx context.Context, serviceID, schemaID string) (bool, error) {
+	num, err := client.GetMongoClient().Count(ctx, CollectionSchema, GeneratorSchemaFilter(ctx, serviceID, schemaID))
+	if err != nil {
+		return false, err
+	}
+	return num != 0, nil
 }
 
 // Instance management
@@ -87,6 +1360,10 @@ func (ds *DataSource) GetInstances(ctx context.Context, request *pb.GetInstances
 // GetProviderInstances returns instances under the specified domain
 func (ds *DataSource) GetProviderInstances(ctx context.Context, request *pb.GetProviderInstancesRequest) (instances []*pb.MicroServiceInstance, rev string, err error) {
 	return nil, "", nil
+}
+
+func (ds *DataSource) GetAllInstances(ctx context.Context, request *pb.GetAllInstancesRequest) (*pb.GetAllInstancesResponse, error) {
+	return &pb.GetAllInstancesResponse{}, nil
 }
 
 func (ds *DataSource) BatchGetProviderInstances(ctx context.Context, request *pb.BatchGetInstancesRequest) (instances []*pb.MicroServiceInstance, rev string, err error) {
@@ -120,67 +1397,4 @@ func (ds *DataSource) HeartbeatSet(ctx context.Context, request *pb.HeartbeatSet
 
 func (ds *DataSource) BatchFind(ctx context.Context, request *pb.BatchFindInstancesRequest) (*pb.BatchFindInstancesResponse, error) {
 	return &pb.BatchFindInstancesResponse{}, nil
-}
-
-func (ds *DataSource) GetAllInstances(ctx context.Context, request *pb.GetAllInstancesRequest) (*pb.GetAllInstancesResponse, error) {
-	return &pb.GetAllInstancesResponse{}, nil
-}
-
-// Schema management
-func (ds *DataSource) ModifySchemas(ctx context.Context, request *pb.ModifySchemasRequest) (*pb.ModifySchemasResponse, error) {
-	return &pb.ModifySchemasResponse{}, nil
-}
-
-func (ds *DataSource) ModifySchema(ctx context.Context, request *pb.ModifySchemaRequest) (*pb.ModifySchemaResponse, error) {
-	return &pb.ModifySchemaResponse{}, nil
-}
-
-func (ds *DataSource) ExistSchema(ctx context.Context, request *pb.GetExistenceRequest) (*pb.GetExistenceResponse, error) {
-	return &pb.GetExistenceResponse{}, nil
-}
-
-func (ds *DataSource) GetSchema(ctx context.Context, request *pb.GetSchemaRequest) (*pb.GetSchemaResponse, error) {
-	return &pb.GetSchemaResponse{}, nil
-}
-
-func (ds *DataSource) GetAllSchemas(ctx context.Context, request *pb.GetAllSchemaRequest) (*pb.GetAllSchemaResponse, error) {
-	return &pb.GetAllSchemaResponse{}, nil
-}
-
-func (ds *DataSource) DeleteSchema(ctx context.Context, request *pb.DeleteSchemaRequest) (*pb.DeleteSchemaResponse, error) {
-	return &pb.DeleteSchemaResponse{}, nil
-}
-
-// Tag management
-func (ds *DataSource) AddTags(ctx context.Context, request *pb.AddServiceTagsRequest) (*pb.AddServiceTagsResponse, error) {
-	return &pb.AddServiceTagsResponse{}, nil
-}
-
-func (ds *DataSource) GetTags(ctx context.Context, request *pb.GetServiceTagsRequest) (*pb.GetServiceTagsResponse, error) {
-	return &pb.GetServiceTagsResponse{}, nil
-}
-
-func (ds *DataSource) UpdateTag(ctx context.Context, request *pb.UpdateServiceTagRequest) (*pb.UpdateServiceTagResponse, error) {
-	return &pb.UpdateServiceTagResponse{}, nil
-}
-
-func (ds *DataSource) DeleteTags(ctx context.Context, request *pb.DeleteServiceTagsRequest) (*pb.DeleteServiceTagsResponse, error) {
-	return &pb.DeleteServiceTagsResponse{}, nil
-}
-
-// White/black list management
-func (ds *DataSource) AddRule(ctx context.Context, request *pb.AddServiceRulesRequest) (*pb.AddServiceRulesResponse, error) {
-	return &pb.AddServiceRulesResponse{}, nil
-}
-
-func (ds *DataSource) GetRules(ctx context.Context, request *pb.GetServiceRulesRequest) (*pb.GetServiceRulesResponse, error) {
-	return &pb.GetServiceRulesResponse{}, nil
-}
-
-func (ds *DataSource) UpdateRule(ctx context.Context, request *pb.UpdateServiceRuleRequest) (*pb.UpdateServiceRuleResponse, error) {
-	return &pb.UpdateServiceRuleResponse{}, nil
-}
-
-func (ds *DataSource) DeleteRule(ctx context.Context, request *pb.DeleteServiceRulesRequest) (*pb.DeleteServiceRulesResponse, error) {
-	return &pb.DeleteServiceRulesResponse{}, nil
 }

--- a/datasource/mongo/ms_test.go
+++ b/datasource/mongo/ms_test.go
@@ -1,0 +1,653 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/mongo"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/server/plugin/quota"
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/go-chassis/v2/storage"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func init() {
+	config := storage.DB{
+		URI: "mongodb://localhost:27017",
+	}
+	client.NewMongoClient(config, []string{mongo.CollectionService, mongo.CollectionRule, mongo.CollectionSchema, mongo.CollectionAccount})
+}
+
+func TestServiceRegister(t *testing.T) {
+	t.Run("Register service by mongo, should pass", func(t *testing.T) {
+		size := quota.DefaultSchemaQuota + 1
+		paths := make([]*pb.ServicePath, 0, size)
+		properties := make(map[string]string, size)
+		for i := 0; i < size; i++ {
+			s := strconv.Itoa(i) + strings.Repeat("x", 253)
+			paths = append(paths, &pb.ServicePath{Path: s, Property: map[string]string{s: s}})
+			properties[s] = s
+		}
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "service-ms-appID_id",
+				AppId:       "service-ms-appID",
+				ServiceName: "service-ms-serviceName",
+				Version:     "32767.32767.32767.32767",
+				Alias:       "service-ms-alias",
+				Level:       "BACK",
+				Status:      "UP",
+				Schemas:     []string{"service-ms-schema"},
+				Paths:       paths,
+				Properties:  properties,
+				Framework: &pb.FrameWorkProperty{
+					Name:    "service-ms-frameworkName",
+					Version: "service-ms-frameworkVersion",
+				},
+				RegisterBy: "SDK",
+				Timestamp:  strconv.FormatInt(time.Now().Unix(), 10),
+			},
+		}
+		request.Service.ModTimestamp = request.Service.Timestamp
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+	})
+	t.Run("Register service with the same id by mongo, should pass", func(t *testing.T) {
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "service-ms-appID_id",
+				AppId:       "service-ms-appID11",
+				ServiceName: "service-ms-serviceName11",
+				Version:     "32767.32767.32767.3276711",
+				Alias:       "service-ms-alias11",
+			},
+		}
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ErrServiceAlreadyExists, resp.Response.GetCode())
+	})
+	t.Run("Register service with the same id by mongo, should pass", func(t *testing.T) {
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "service-ms-appID_id_test",
+				AppId:       "service-ms-appID",
+				ServiceName: "service-ms-serviceName",
+				Version:     "32767.32767.32767.32767",
+				Alias:       "service-ms-alias",
+			},
+		}
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NotNil(t, resp)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ErrServiceAlreadyExists, resp.Response.GetCode())
+	})
+}
+
+func TestGetService(t *testing.T) {
+	t.Run("get a exist service by mongo, should pass", func(t *testing.T) {
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "ms-service-query-id",
+				ServiceName: "ms-service-query",
+				AppId:       "default",
+				Version:     "1.0.4",
+				Level:       "BACK",
+				Properties:  make(map[string]string),
+			},
+		}
+
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		request = &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "ms-service-query-id1",
+				ServiceName: "ms-service-query1",
+				AppId:       "default",
+				Version:     "1.0.4",
+				Level:       "BACK",
+				Properties:  make(map[string]string),
+			},
+		}
+
+		resp, err = datasource.Instance().RegisterService(getContext(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		// search service by serviceID
+		queryResp, err := datasource.Instance().GetService(getContext(), &pb.GetServiceRequest{
+			ServiceId: "ms-service-query-id",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, queryResp.Response.GetCode())
+	})
+	t.Run("get all service by mongo, should pass", func(t *testing.T) {
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "ms-service-query-id3",
+				ServiceName: "ms-service-query3",
+				AppId:       "default",
+				Version:     "1.0.4",
+				Level:       "BACK",
+				Properties:  make(map[string]string),
+			},
+		}
+
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		// search service by serviceID
+		queryResp, err := datasource.Instance().GetServices(getContext(), &pb.GetServicesRequest{})
+		assert.NoError(t, err)
+		assert.Greater(t, len(queryResp.Services), 0)
+	})
+	t.Run("get a exist service with id by mongo, should pass", func(t *testing.T) {
+		queryResp, err := datasource.Instance().ExistServiceByID(getContext(), &pb.GetExistenceByIDRequest{
+			ServiceId: "ms-service-query-id1",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, queryResp.Response.GetCode())
+		assert.Equal(t, true, queryResp.Exist)
+	})
+	t.Run("query a service by a not existed serviceId, should not pass", func(t *testing.T) {
+		// not exist service
+		resp, err := datasource.Instance().GetService(getContext(), &pb.GetServiceRequest{
+			ServiceId: "no-exist-service",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ErrServiceNotExists, resp.Response.GetCode())
+	})
+
+}
+
+// need mongodb cluster
+//func TestServiceDelete(t *testing.T) {
+//	t.Run("delete service by mongo, should pass", func(t *testing.T) {
+//		request := &pb.CreateServiceRequest{
+//			Service: &pb.MicroService{
+//				ServiceId:   "ms-service-delete-new-id",
+//				ServiceName: "ms-service-delete",
+//				AppId:       "default",
+//				Version:     "1.0.4",
+//				Level:       "BACK",
+//				Properties:  make(map[string]string),
+//			},
+//		}
+//
+//		resp, err := datasource.Instance().RegisterService(getContext(), request)
+//		assert.NoError(t, err)
+//		assert.Equal(t, resp.Response.GetCode(), pb.ResponseSuccess)
+//
+//		res, err := datasource.Instance().UnregisterService(getContext(), &pb.DeleteServiceRequest{
+//			ServiceId: "ms-service-delete-new-id",
+//			Force:     false,
+//		})
+//		fmt.Println(res.Response.Message)
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, res.Response.GetCode())
+//	})
+//}
+
+func TestUpdateService(t *testing.T) {
+	t.Run("update service by mongo, should pass", func(t *testing.T) {
+		request := &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "ms-service-update-new-id",
+				ServiceName: "ms-service-update",
+				AppId:       "default",
+				Version:     "1.0.4",
+				Level:       "BACK",
+				Properties:  make(map[string]string),
+			},
+		}
+
+		resp, err := datasource.Instance().RegisterService(getContext(), request)
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Response.GetCode(), pb.ResponseSuccess)
+
+		requestNew := &pb.UpdateServicePropsRequest{
+			ServiceId:  "ms-service-update-new-id",
+			Properties: make(map[string]string),
+		}
+		requestNew.Properties["k"] = "v"
+		res, err := datasource.Instance().UpdateService(getContext(), requestNew)
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, res.Response.GetCode())
+
+		respGetService, err := datasource.Instance().GetService(getContext(), &pb.GetServiceRequest{ServiceId: "ms-service-update-new-id"})
+		assert.NoError(t, err)
+		assert.Equal(t, "v", respGetService.Service.Properties["k"])
+	})
+}
+
+func TestTagsAdd(t *testing.T) {
+	// create service
+	t.Run("create service", func(t *testing.T) {
+		svc1 := &pb.MicroService{
+			ServiceId:   "service_tag_id",
+			AppId:       "create_tag_group_ms",
+			ServiceName: "create_tag_service_ms",
+			Version:     "1.0.0",
+			Level:       "FRONT",
+			Status:      pb.MS_UP,
+		}
+		resp, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: svc1,
+		})
+		assert.NoError(t, err)
+		assert.NotEqual(t, "", resp.ServiceId)
+	})
+
+	//
+	t.Run("the request is valid", func(t *testing.T) {
+		defaultQuota := quota.DefaultTagQuota
+		tags := make(map[string]string, defaultQuota)
+		for i := 0; i < defaultQuota; i++ {
+			s := "tag" + strconv.Itoa(i)
+			tags[s] = s
+		}
+		resp, err := datasource.Instance().AddTags(getContext(), &pb.AddServiceTagsRequest{
+			ServiceId: "service_tag_id",
+			Tags:      tags,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+	})
+
+}
+
+func TestTagsGet(t *testing.T) {
+	t.Run("create service and add tags", func(t *testing.T) {
+		svc := &pb.MicroService{
+			ServiceId:   "get_tag_group_ms_id",
+			AppId:       "get_tag_group_ms",
+			ServiceName: "get_tag_service_ms",
+			Version:     "1.0.0",
+			Level:       "FRONT",
+			Status:      pb.MS_UP,
+		}
+		resp, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: svc,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		respAddTags, err := datasource.Instance().AddTags(getContext(), &pb.AddServiceTagsRequest{
+			ServiceId: "get_tag_group_ms_id",
+			Tags: map[string]string{
+				"a": "test",
+				"b": "b",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddTags.Response.GetCode())
+	})
+	t.Run("the request is valid", func(t *testing.T) {
+		resp, err := datasource.Instance().GetTags(getContext(), &pb.GetServiceTagsRequest{
+			ServiceId: "get_tag_group_ms_id",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+		assert.Equal(t, "test", resp.Tags["a"])
+	})
+}
+
+func TestTagUpdate(t *testing.T) {
+	t.Run("add service and add tags", func(t *testing.T) {
+		svc := &pb.MicroService{
+			ServiceId:   "update_tag_group_ms_id",
+			AppId:       "update_tag_group_ms",
+			ServiceName: "update_tag_service_ms",
+			Version:     "1.0.0",
+			Level:       "FRONT",
+			Status:      pb.MS_UP,
+		}
+		resp, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: svc,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		respAddTags, err := datasource.Instance().AddTags(getContext(), &pb.AddServiceTagsRequest{
+			ServiceId: "update_tag_group_ms_id",
+			Tags: map[string]string{
+				"a": "test",
+				"b": "b",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddTags.Response.GetCode())
+	})
+
+	t.Run("the request is valid", func(t *testing.T) {
+		resp, err := datasource.Instance().UpdateTag(getContext(), &pb.UpdateServiceTagRequest{
+			ServiceId: "update_tag_group_ms_id",
+			Key:       "a",
+			Value:     "update",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+	})
+}
+
+func TestTagsDelete(t *testing.T) {
+	t.Run("create service and add tags", func(t *testing.T) {
+		resp, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "delete_tag_group_ms_id",
+				AppId:       "delete_tag_group_ms",
+				ServiceName: "delete_tag_service_ms",
+				Version:     "1.0.0",
+				Level:       "FRONT",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		respAddTages, err := datasource.Instance().AddTags(getContext(), &pb.AddServiceTagsRequest{
+			ServiceId: "delete_tag_group_ms_id",
+			Tags: map[string]string{
+				"a": "test",
+				"b": "b",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddTages.Response.GetCode())
+	})
+	t.Run("the request is valid", func(t *testing.T) {
+		resp, err := datasource.Instance().DeleteTags(getContext(), &pb.DeleteServiceTagsRequest{
+			ServiceId: "delete_tag_group_ms_id",
+			Keys:      []string{"b"},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		respTags, err := datasource.Instance().GetTags(getContext(), &pb.GetServiceTagsRequest{
+			ServiceId: "delete_tag_group_ms_id",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respTags.Response.GetCode())
+		assert.Equal(t, "", respTags.Tags["b"])
+	})
+}
+
+func TestRuleAdd(t *testing.T) {
+	t.Run("register service and datasource.Instance()", func(t *testing.T) {
+		respCreateService, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "create_rule_group_ms_id",
+				AppId:       "create_rule_group_ms",
+				ServiceName: "create_rule_service_ms",
+				Version:     "1.0.0",
+				Level:       "FRONT",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+	})
+	t.Run("request is valid", func(t *testing.T) {
+		respAddRule, err := datasource.Instance().AddRule(getContext(), &pb.AddServiceRulesRequest{
+			ServiceId: "create_rule_group_ms_id",
+			Rules: []*pb.AddOrUpdateServiceRule{
+				{
+					RuleType:    "BLACK",
+					Attribute:   "ServiceName",
+					Pattern:     "Test*",
+					Description: "test black",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddRule.Response.GetCode())
+		ruleId := respAddRule.RuleIds[0]
+		assert.NotEqual(t, "", ruleId)
+	})
+	t.Run("request rule is already exist", func(t *testing.T) {
+		respAddRule, err := datasource.Instance().AddRule(getContext(), &pb.AddServiceRulesRequest{
+			ServiceId: "create_rule_group_ms_id",
+			Rules: []*pb.AddOrUpdateServiceRule{
+				{
+					RuleType:    "BLACK",
+					Attribute:   "ServiceName",
+					Pattern:     "Test*",
+					Description: "test black",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddRule.Response.GetCode())
+		assert.Equal(t, 0, len(respAddRule.RuleIds))
+	})
+}
+
+func TestRuleGet(t *testing.T) {
+	t.Run("register service and rules", func(t *testing.T) {
+		respCreateService, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "get_rule_group_ms_id",
+				AppId:       "get_rule_group_ms",
+				ServiceName: "get_rule_service_ms",
+				Version:     "1.0.0",
+				Level:       "FRONT",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+
+		respAddRule, err := datasource.Instance().AddRule(getContext(), &pb.AddServiceRulesRequest{
+			ServiceId: "get_rule_group_ms_id",
+			Rules: []*pb.AddOrUpdateServiceRule{
+				{
+					RuleType:    "BLACK",
+					Attribute:   "ServiceName",
+					Pattern:     "Test*",
+					Description: "test BLACK",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddRule.Response.GetCode())
+		ruleId := respAddRule.RuleIds[0]
+		assert.NotEqual(t, "", ruleId)
+	})
+	t.Run("get when request is valid", func(t *testing.T) {
+		respGetRule, err := datasource.Instance().GetRules(getContext(), &pb.GetServiceRulesRequest{
+			ServiceId: "get_rule_group_ms_id",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respGetRule.Response.GetCode())
+		assert.Equal(t, 1, len(respGetRule.Rules))
+	})
+}
+
+func TestRuleDelete(t *testing.T) {
+	var ruleId string
+	t.Run("register service and rules", func(t *testing.T) {
+		respCreateService, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "delete_rule_group_ms_id",
+				AppId:       "delete_rule_group_ms",
+				ServiceName: "delete_rule_service_ms",
+				Version:     "1.0.0",
+				Level:       "FRONT",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+
+		respAddRule, err := datasource.Instance().AddRule(getContext(), &pb.AddServiceRulesRequest{
+			ServiceId: "delete_rule_group_ms_id",
+			Rules: []*pb.AddOrUpdateServiceRule{
+				{
+					RuleType:    "BLACK",
+					Attribute:   "ServiceName",
+					Pattern:     "Test*",
+					Description: "test BLACK",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddRule.Response.GetCode())
+		ruleId = respAddRule.RuleIds[0]
+	})
+	t.Run("delete when request is valid", func(t *testing.T) {
+		resp, err := datasource.Instance().DeleteRule(getContext(), &pb.DeleteServiceRulesRequest{
+			ServiceId: "delete_rule_group_ms_id",
+			RuleIds:   []string{ruleId},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+
+		respGetRule, err := datasource.Instance().GetRules(getContext(), &pb.GetServiceRulesRequest{
+			ServiceId: "delete_rule_group_ms_id",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+		assert.Equal(t, 1, len(respGetRule.Rules))
+	})
+}
+
+func TestRuleUpdate(t *testing.T) {
+	var ruleId string
+	t.Run("create service and rules", func(t *testing.T) {
+		respCreateService, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceId:   "update_rule_group_ms_id",
+				AppId:       "update_rule_group_ms",
+				ServiceName: "update_rule_service_ms",
+				Version:     "1.0.0",
+				Level:       "FRONT",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+
+		respAddRule, err := datasource.Instance().AddRule(getContext(), &pb.AddServiceRulesRequest{
+			ServiceId: "update_rule_group_ms_id",
+			Rules: []*pb.AddOrUpdateServiceRule{
+				{
+					RuleType:    "BLACK",
+					Attribute:   "ServiceName",
+					Pattern:     "Test*",
+					Description: "test BLACK",
+				},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, respAddRule.Response.GetCode())
+		assert.NotEqual(t, "", respAddRule.RuleIds[0])
+		ruleId = respAddRule.RuleIds[0]
+	})
+	t.Run("update when request is valid", func(t *testing.T) {
+		resp, err := datasource.Instance().UpdateRule(getContext(), &pb.UpdateServiceRuleRequest{
+			ServiceId: "update_rule_group_ms_id",
+			RuleId:    ruleId,
+			Rule: &pb.AddOrUpdateServiceRule{
+				RuleType:    "BLACK",
+				Attribute:   "AppId",
+				Pattern:     "Test*",
+				Description: "test white update",
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+	})
+}
+
+// 需要多集群mongo支持
+//func TestSchema(t *testing.T) {
+//	t.Run("create a schema in production env", func(t *testing.T) {
+//		respCreateService, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+//			Service: &pb.MicroService{
+//				ServiceId:   "create_schema_prod_service_ms_id1",
+//				AppId:       "create_schema_prod_service_ms",
+//				ServiceName: "create_schema_service_service_ms",
+//				Version:     "1.0.0",
+//				Level:       "FRONT",
+//				Status:      pb.MS_UP,
+//				Environment: pb.ENV_PROD,
+//			},
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+//
+//		respCreateService, err = datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+//			Service: &pb.MicroService{
+//				ServiceId:   "create_schema_prod_service_ms_id2",
+//				AppId:       "create_schema_prod_service_ms",
+//				ServiceName: "create_schema_service_service_ms",
+//				Version:     "1.0.1",
+//				Level:       "FRONT",
+//				Schemas: []string{
+//					"first_schemaId_service_ms",
+//					"second_schemaId_service_ms",
+//				},
+//				Status:      pb.MS_UP,
+//				Environment: pb.ENV_PROD,
+//			},
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
+//
+//		respModifySchema, err := datasource.Instance().ModifySchema(getContext(), &pb.ModifySchemaRequest{
+//			ServiceId: "create_schema_prod_service_ms_id1",
+//			SchemaId:  "first_schemaId_service_ms",
+//			Schema:    "first_schema_service_ms",
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, respModifySchema.Response.GetCode())
+//
+//		respModifySchema, err = datasource.Instance().ModifySchema(getContext(), &pb.ModifySchemaRequest{
+//			ServiceId: "create_schema_prod_service_ms_id1",
+//			SchemaId:  "first_schemaId_service_ms",
+//			Schema:    "first_schema_change_service_ms",
+//			Summary:   "first0summary1change_service_ms",
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, respModifySchema.Response.GetCode())
+//		existRes, err := datasource.Instance().ExistSchema(getContext(), &pb.GetExistenceRequest{
+//			ServiceId: "create_schema_prod_service_ms_id1",
+//			SchemaId:  "first_schemaId_service_ms",
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, pb.ResponseSuccess, existRes.Response.GetCode())
+//		assert.Equal(t, "first0summary1change_service_ms", existRes.Summary)
+//
+//		resSchemas, err := datasource.Instance().GetAllSchemas(getContext(), &pb.GetAllSchemaRequest{
+//			ServiceId:  "create_schema_prod_service_ms_id1",
+//			WithSchema: true,
+//		})
+//		assert.NoError(t, err)
+//		assert.Equal(t, 1, len(resSchemas.Schemas))
+//	})
+//}

--- a/datasource/schema_util.go
+++ b/datasource/schema_util.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasource
+
+import (
+	pb "github.com/go-chassis/cari/discovery"
+)
+
+// @titile SchemasAnalysis
+// @description schemasanlysis decide the schema to be deleted,updated or added
+// @param schemas []*pb.Schema "the schemas from request"
+// @param schemasFromDb []*pb.Schema "the schemas from database by the serviceID"
+// @param schemaIDsInService []string "the schema field in service struct"
+func SchemasAnalysis(schemas []*pb.Schema, schemasFromDb []*pb.Schema, schemaIDsInService []string) (
+	[]*pb.Schema, []*pb.Schema, []*pb.Schema, []string) {
+	needUpdateSchemas := make([]*pb.Schema, 0, len(schemas))
+	needAddSchemas := make([]*pb.Schema, 0, len(schemas))
+	needDeleteSchemas := make([]*pb.Schema, 0, len(schemasFromDb))
+	nonExistSchemaIds := make([]string, 0, len(schemas))
+
+	duplicate := make(map[string]struct{})
+	for _, schema := range schemas {
+		if _, ok := duplicate[schema.SchemaId]; ok {
+			continue
+		}
+		duplicate[schema.SchemaId] = struct{}{}
+
+		exist := false
+		for _, schemaFromDb := range schemasFromDb {
+			if schema.SchemaId == schemaFromDb.SchemaId {
+				needUpdateSchemas = append(needUpdateSchemas, schema)
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			needAddSchemas = append(needAddSchemas, schema)
+		}
+
+		exist = false
+		for _, schemaID := range schemaIDsInService {
+			if schema.SchemaId == schemaID {
+				exist = true
+			}
+		}
+		if !exist {
+			nonExistSchemaIds = append(nonExistSchemaIds, schema.SchemaId)
+		}
+	}
+
+	for _, schemaFromDb := range schemasFromDb {
+		exist := false
+		for _, schema := range schemas {
+			if schema.SchemaId == schemaFromDb.SchemaId {
+				exist = true
+				break
+			}
+		}
+		if !exist {
+			needDeleteSchemas = append(needDeleteSchemas, schemaFromDb)
+		}
+	}
+
+	return needUpdateSchemas, needAddSchemas, needDeleteSchemas, nonExistSchemaIds
+}


### PR DESCRIPTION
1.service,tag融合为单张表，尽可能减少事务操作
2.schema涉及和service的同时更新，事务无法避免
3.quota，version,service中涉及dep，instance的删除更新后续PR补齐
4.当前只保证了基础功能的ut，先不影响性能测试，后续PR补齐分支，且事务ut需要mongo集群。