### PR TITLE
Revert "[SCB-2094] Heartbeat interface optimization (#772)"

### DIFF
--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeat.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeat.go
@@ -21,16 +21,16 @@ import (
 	"context"
 	"time"
 
-	"go.mongodb.org/mongo-driver/bson"
-
 	"github.com/apache/servicecomb-service-center/datasource/mongo"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 	"github.com/apache/servicecomb-service-center/pkg/log"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
-func updateInstanceRefreshTime(ctx context.Context, instanceID string) error {
+func updateInstanceRefreshTime(ctx context.Context, serviceID string, instanceID string) error {
 	filter := bson.M{
 		mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instanceID,
+		mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  serviceID,
 	}
 	update := bson.M{
 		"$set": bson.M{mongo.RefreshTime: time.Now()},

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeat_test.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeat_test.go
@@ -22,14 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/servicecomb-service-center/datasource/mongo"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/pkg/log"
 	pb "github.com/go-chassis/cari/discovery"
 	"github.com/go-chassis/go-chassis/v2/storage"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
-
-	"github.com/apache/servicecomb-service-center/datasource/mongo"
-	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
-	"github.com/apache/servicecomb-service-center/pkg/log"
 )
 
 func init() {
@@ -41,7 +40,7 @@ func init() {
 
 func TestUpdateInstanceRefreshTime(t *testing.T) {
 	t.Run("update instance refresh time: if the instance does not exist,the update should fail", func(t *testing.T) {
-		err := updateInstanceRefreshTime(context.Background(), "not-exist")
+		err := updateInstanceRefreshTime(context.Background(), "not-exist", "not-exist")
 		log.Error("", err)
 		assert.NotNil(t, err)
 	})
@@ -56,10 +55,11 @@ func TestUpdateInstanceRefreshTime(t *testing.T) {
 		}
 		_, err := client.GetMongoClient().Insert(context.Background(), mongo.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
-		err = updateInstanceRefreshTime(context.Background(), instance1.InstanceInfo.InstanceId)
+		err = updateInstanceRefreshTime(context.Background(), instance1.InstanceInfo.ServiceId, instance1.InstanceInfo.InstanceId)
 		assert.Equal(t, nil, err)
 		filter := bson.M{
 			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instance1.InstanceInfo.InstanceId,
+			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  instance1.InstanceInfo.ServiceId,
 		}
 		result, err := client.GetMongoClient().FindOne(context.Background(), mongo.CollectionInstance, filter)
 		assert.Nil(t, err)

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker.go
@@ -19,13 +19,13 @@ package heartbeatchecker
 
 import (
 	"context"
-	"fmt"
-
-	pb "github.com/go-chassis/cari/discovery"
 
 	"github.com/apache/servicecomb-service-center/datasource/mongo/heartbeat"
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	"github.com/apache/servicecomb-service-center/pkg/util"
+	pb "github.com/go-chassis/cari/discovery"
+
+	"fmt"
 )
 
 func init() {
@@ -41,7 +41,7 @@ func NewHeartBeatChecker(opts heartbeat.Options) (heartbeat.HealthCheck, error) 
 
 func (h *HeartBeatChecker) Heartbeat(ctx context.Context, request *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error) {
 	remoteIP := util.GetIPFromContext(ctx)
-	err := updateInstanceRefreshTime(ctx, request.InstanceId)
+	err := updateInstanceRefreshTime(ctx, request.ServiceId, request.InstanceId)
 	if err != nil {
 		log.Error(fmt.Sprintf("heartbeat failed, instance[%s]. operator %s", request.InstanceId, remoteIP), err)
 		resp := &pb.HeartbeatResponse{

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker_test.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker_test.go
@@ -22,12 +22,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/servicecomb-service-center/datasource/mongo"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 	pb "github.com/go-chassis/cari/discovery"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
-
-	"github.com/apache/servicecomb-service-center/datasource/mongo"
-	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 )
 
 func TestHeartbeat(t *testing.T) {


### PR DESCRIPTION
再调试mongo的ms_test测试用例时发现，发送心跳时，需要利用serviceID以及instanceID当做查询条件，不能单独使用instanceID当查询条件，所以原先的逻辑是正确的，需要回退一下

