### PR TITLE
[SCB-2094] Bug fixes: The heartbeat reporting interface needs to use …

### DIFF
--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeat.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeat.go
@@ -28,9 +28,10 @@ import (
 	"github.com/apache/servicecomb-service-center/pkg/log"
 )
 
-func updateInstanceRefreshTime(ctx context.Context, instanceID string) error {
+func updateInstanceRefreshTime(ctx context.Context, serviceID string, instanceID string) error {
 	filter := bson.M{
 		mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instanceID,
+		mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  serviceID,
 	}
 	update := bson.M{
 		"$set": bson.M{mongo.RefreshTime: time.Now()},

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeat_test.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeat_test.go
@@ -41,7 +41,7 @@ func init() {
 
 func TestUpdateInstanceRefreshTime(t *testing.T) {
 	t.Run("update instance refresh time: if the instance does not exist,the update should fail", func(t *testing.T) {
-		err := updateInstanceRefreshTime(context.Background(), "not-exist")
+		err := updateInstanceRefreshTime(context.Background(), "not-exist", "not-exist")
 		log.Error("", err)
 		assert.NotNil(t, err)
 	})
@@ -56,10 +56,11 @@ func TestUpdateInstanceRefreshTime(t *testing.T) {
 		}
 		_, err := client.GetMongoClient().Insert(context.Background(), mongo.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
-		err = updateInstanceRefreshTime(context.Background(), instance1.InstanceInfo.InstanceId)
+		err = updateInstanceRefreshTime(context.Background(), instance1.InstanceInfo.ServiceId, instance1.InstanceInfo.InstanceId)
 		assert.Equal(t, nil, err)
 		filter := bson.M{
 			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instance1.InstanceInfo.InstanceId,
+			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  instance1.InstanceInfo.ServiceId,
 		}
 		result, err := client.GetMongoClient().FindOne(context.Background(), mongo.CollectionInstance, filter)
 		assert.Nil(t, err)
@@ -69,6 +70,7 @@ func TestUpdateInstanceRefreshTime(t *testing.T) {
 		assert.NotEqual(t, instance1.RefreshTime, ins.RefreshTime)
 		filter = bson.M{
 			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instance1.InstanceInfo.InstanceId,
+			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  instance1.InstanceInfo.ServiceId,
 		}
 		_, err = client.GetMongoClient().Delete(context.Background(), mongo.CollectionInstance, filter)
 		assert.Nil(t, err)

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker.go
@@ -41,7 +41,7 @@ func NewHeartBeatChecker(opts heartbeat.Options) (heartbeat.HealthCheck, error) 
 
 func (h *HeartBeatChecker) Heartbeat(ctx context.Context, request *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error) {
 	remoteIP := util.GetIPFromContext(ctx)
-	err := updateInstanceRefreshTime(ctx, request.InstanceId)
+	err := updateInstanceRefreshTime(ctx, request.ServiceId, request.InstanceId)
 	if err != nil {
 		log.Error(fmt.Sprintf("heartbeat failed, instance[%s]. operator %s", request.InstanceId, remoteIP), err)
 		resp := &pb.HeartbeatResponse{

--- a/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker_test.go
+++ b/datasource/mongo/heartbeat/heartbeatchecker/heartbeatchecker_test.go
@@ -60,6 +60,7 @@ func TestHeartbeat(t *testing.T) {
 		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
 		filter := bson.M{
 			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnInstanceID}): instance1.InstanceInfo.InstanceId,
+			mongo.StringBuilder([]string{mongo.ColumnInstanceInfo, mongo.ColumnServiceID}):  instance1.InstanceInfo.ServiceId,
 		}
 		_, err = client.GetMongoClient().Delete(context.Background(), mongo.CollectionInstance, filter)
 		assert.Nil(t, err)


### PR DESCRIPTION
## [SCB-2094] Bug fixes: The heartbeat reporting interface needs to use serviceid to query

在调整mongo的ms_test用例时，发现instance发送心跳用例要求把serviceID和instanceID一起当做查询条件，之前性能优化只用instanceID来查询逻辑欠缺，应还原之前的逻辑。