### PR TITLE
implement of mongo DumpCache interface and optimization of syncer

### DIFF
--- a/client/microservice.go
+++ b/client/microservice.go
@@ -94,7 +94,7 @@ func (c *Client) ServiceExistence(ctx context.Context, domain, project string, a
 	query := url.Values{}
 	query.Set("type", "microservice")
 	query.Set("env", env)
-	query.Set("appID", appID)
+	query.Set("appId", appID)
 	query.Set("serviceName", serviceName)
 	query.Set("version", versionRule)
 

--- a/datasource/mongo/mongo.go
+++ b/datasource/mongo/mongo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/heartbeat"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	"github.com/apache/servicecomb-service-center/server/config"
 	"github.com/go-chassis/go-chassis/v2/storage"
@@ -72,6 +73,8 @@ func (ds *DataSource) initialize() error {
 	if err != nil {
 		return err
 	}
+	// init mongo cache
+	ds.initStore()
 	return nil
 }
 
@@ -117,4 +120,13 @@ func (ds *DataSource) createIndexes() (err error) {
 		return
 	}
 	return
+}
+
+func (ds *DataSource) initStore() {
+	if !config.GetRegistry().EnableCache {
+		log.Debug("cache is disabled")
+		return
+	}
+	sd.Store().Run()
+	<-sd.Store().Ready()
 }

--- a/datasource/mongo/sd/cache.go
+++ b/datasource/mongo/sd/cache.go
@@ -1,0 +1,46 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package sd
+
+// Cache stores db data.
+type Cache interface {
+	CacheReader
+
+	Put(id string, v interface{})
+
+	Remove(id string)
+
+	MarkDirty()
+
+	Dirty() bool
+
+	Clear()
+}
+
+// CacheReader reads k-v data.
+type CacheReader interface {
+	Name() string // The name of implementation
+
+	Size() int // the bytes size of the cache
+
+	// Get gets a value by id
+	Get(id string) interface{}
+
+	// ForEach executes the given function for each of the k-v
+	ForEach(iter func(k string, v interface{}) (next bool))
+}

--- a/datasource/mongo/sd/common.go
+++ b/datasource/mongo/sd/common.go
@@ -1,0 +1,36 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+package sd
+
+import (
+	"time"
+)
+
+const (
+	// force re-list
+	DefaultForceListInterval = 10
+
+	minWaitInterval = 1 * time.Second
+	eventBlockSize  = 1000
+	eventBusSize    = 1000
+
+	insertOp  = "insertOp"
+	updateOp  = "updateOp"
+	replaceOp = "replaceOp"
+	deleteOp  = "delete"
+)

--- a/datasource/mongo/sd/event_proxy.go
+++ b/datasource/mongo/sd/event_proxy.go
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+)
+
+var (
+	eventProxies = &sync.Map{}
+)
+
+type MongoEventProxy struct {
+	evtHandleFuncs []MongoEventFunc
+	lock           sync.RWMutex
+}
+
+func (h *MongoEventProxy) AddHandleFunc(f MongoEventFunc) {
+	h.lock.Lock()
+	h.evtHandleFuncs = append(h.evtHandleFuncs, f)
+	h.lock.Unlock()
+}
+
+func (h *MongoEventProxy) OnEvent(evt MongoEvent) {
+	h.lock.RLock()
+	for _, f := range h.evtHandleFuncs {
+		f(evt)
+	}
+	h.lock.RUnlock()
+}
+
+// InjectOptions will inject a resource changed event callback function in Config
+func (h *MongoEventProxy) InjectOptions(options *Options) *Options {
+	return options.AppendEventFunc(h.OnEvent)
+}
+
+func EventProxy(t string) *MongoEventProxy {
+	proxy, ok := eventProxies.Load(t)
+	if !ok {
+		proxy = &MongoEventProxy{}
+		eventProxies.Store(t, proxy)
+	}
+	return proxy.(*MongoEventProxy)
+}
+
+func AddEventHandler(h MongoEventHandler) {
+	EventProxy(h.Type()).AddHandleFunc(h.OnEvent)
+	log.Info(fmt.Sprintf("register event handler[%s] %s", h.Type(), util.Reflect(h).Name()))
+}

--- a/datasource/mongo/sd/event_proxy_test.go
+++ b/datasource/mongo/sd/event_proxy_test.go
@@ -1,0 +1,103 @@
+package sd
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-chassis/cari/discovery"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddHandleFuncAndOnEvent(t *testing.T) {
+	funcs := []MongoEventFunc{}
+	mongoEventProxy := MongoEventProxy{
+		evtHandleFuncs: funcs,
+	}
+	mongoEvent := MongoEvent{
+		DocumentID: "",
+		BusinessID: "",
+		Type:       discovery.EVT_CREATE,
+		Value:      1,
+	}
+	mongoEventProxy.evtHandleFuncs = funcs
+	assert.Equal(t, 0, len(mongoEventProxy.evtHandleFuncs),
+		"size of evtHandleFuncs is zero")
+	t.Run("AddHandleFunc one time", func(t *testing.T) {
+		mongoEventProxy.AddHandleFunc(mongoEventFuncGet())
+		mongoEventProxy.OnEvent(mongoEvent)
+		assert.Equal(t, 1, len(mongoEventProxy.evtHandleFuncs))
+	})
+	t.Run("AddHandleFunc three times", func(t *testing.T) {
+		for i := 0; i < 5; i++ {
+			mongoEventProxy.AddHandleFunc(mongoEventFuncGet())
+			mongoEventProxy.OnEvent(mongoEvent)
+		}
+		assert.Equal(t, 6, len(mongoEventProxy.evtHandleFuncs))
+	})
+}
+
+type mockInstanceEventHandler struct {
+}
+
+func (h *mockInstanceEventHandler) Type() string {
+	return instance
+}
+
+func (h *mockInstanceEventHandler) OnEvent(MongoEvent) {
+
+}
+
+func TestAddEventHandler(t *testing.T) {
+	AddEventHandler(&mockInstanceEventHandler{})
+
+}
+
+func TestInjectConfig(t *testing.T) {
+	funcs := []MongoEventFunc{}
+	mongoEventProxy := MongoEventProxy{
+		evtHandleFuncs: funcs,
+	}
+	t.Run("inject config without config OnEvent", func(t *testing.T) {
+		options := Options{
+			Key: "",
+		}
+		injectedOptions := mongoEventProxy.InjectOptions(&options)
+		assert.NotNil(t, injectedOptions.OnEvent)
+	})
+	t.Run("inject config with config OnEvent", func(t *testing.T) {
+		options := Options{
+			Key:     "",
+			OnEvent: mongoEventFunc,
+		}
+		injectedOptions := mongoEventProxy.InjectOptions(&options)
+		assert.NotNil(t, injectedOptions.OnEvent)
+	})
+}
+
+func TestEventProxy(t *testing.T) {
+	t.Run("when there is no such a proxy in eventProxies", func(t *testing.T) {
+		eventProxies = &sync.Map{}
+		proxy := EventProxy("new")
+		p, ok := eventProxies.Load("new")
+		//assert.Equal(t, 1, , "add an new proxy")
+		assert.Equal(t, true, ok)
+		assert.NotNil(t, p, "proxy is not nil")
+		assert.Nil(t, proxy.evtHandleFuncs)
+	})
+
+	t.Run("when there is no such a proxy in eventProxies", func(t *testing.T) {
+		eventProxies = &sync.Map{}
+		mongoEventFunc := []MongoEventFunc{mongoEventFuncGet()}
+		mongoEventProxy := MongoEventProxy{
+			evtHandleFuncs: mongoEventFunc,
+		}
+		eventProxies.Store("a", &mongoEventProxy)
+		proxy := EventProxy("a")
+		//assert.Equal(t, 1, len(eventProxies), "find the proxy")
+		p, ok := eventProxies.Load("a")
+		assert.Equal(t, true, ok)
+		assert.Equal(t, &mongoEventProxy, p)
+		assert.NotNil(t, p, "proxy is not nil")
+		assert.NotNil(t, proxy.evtHandleFuncs)
+	})
+}

--- a/datasource/mongo/sd/listwatch.go
+++ b/datasource/mongo/sd/listwatch.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type ListWatchConfig struct {
+	Timeout time.Duration
+	Context context.Context
+}
+
+func (lo *ListWatchConfig) String() string {
+	return fmt.Sprintf("{timeout: %s}", lo.Timeout)
+}
+
+type ListWatch interface {
+	List(op ListWatchConfig) (*MongoListWatchResponse, error)
+	// not support new multiple watchers
+	Watch(op ListWatchConfig) Watcher
+
+	DoWatch(ctx context.Context, f func(*MongoListWatchResponse)) error
+
+	ResumeToken() bson.Raw
+}

--- a/datasource/mongo/sd/listwatch_inner.go
+++ b/datasource/mongo/sd/listwatch_inner.go
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"go.mongodb.org/mongo-driver/bson"
+	md "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type innerListWatch struct {
+	Key         string
+	resumeToken bson.Raw
+}
+
+func (lw *innerListWatch) List(op ListWatchConfig) (*MongoListWatchResponse, error) {
+	otCtx, cancel := context.WithTimeout(op.Context, op.Timeout)
+	defer cancel()
+
+	resp, err := client.GetMongoClient().Find(otCtx, lw.Key, bson.M{})
+	if err != nil {
+		log.Error(fmt.Sprintf("list key %s failed", lw.Key), err)
+		return nil, err
+	}
+
+	lwRsp := &MongoListWatchResponse{}
+	lwRsp.Infos = make([]MongoInfo, 0)
+	for resp.Next(context.Background()) {
+		info := lw.doParseDocumentToMongoInfo(resp.Current)
+		lwRsp.Infos = append(lwRsp.Infos, info)
+	}
+
+	return lwRsp, nil
+}
+
+func (lw *innerListWatch) ResumeToken() bson.Raw {
+	return lw.resumeToken
+}
+
+func (lw *innerListWatch) setResumeToken(resumeToken bson.Raw) {
+	lw.resumeToken = resumeToken
+}
+
+func (lw *innerListWatch) Watch(op ListWatchConfig) Watcher {
+	return newInnerWatcher(lw, op)
+}
+
+func (lw *innerListWatch) DoWatch(ctx context.Context, f func(*MongoListWatchResponse)) error {
+	csOptions := &options.ChangeStreamOptions{}
+	csOptions.SetFullDocument(options.UpdateLookup)
+
+	resumeToken := lw.ResumeToken()
+	if resumeToken != nil {
+		csOptions.SetResumeAfter(resumeToken)
+	}
+
+	resp, err := client.GetMongoClient().Watch(ctx, lw.Key, md.Pipeline{}, csOptions)
+
+	if err != nil {
+		log.Error(fmt.Sprintf("watch table %s failed", lw.Key), err)
+		f(nil)
+		return err
+	}
+
+	for resp.Next(ctx) {
+		lwRsp := &MongoListWatchResponse{}
+
+		lw.setResumeToken(resp.ResumeToken())
+
+		wRsp := &MongoWatchResponse{}
+		err := bson.Unmarshal(resp.Current, &wRsp)
+
+		if err != nil {
+			log.Error("error to parse bson raw to mongo watch response", err)
+			return err
+		}
+
+		info := lw.doParseWatchRspToMongoInfo(wRsp)
+
+		lwRsp.OperationType = wRsp.OperationType
+		lwRsp.Infos = append(lwRsp.Infos, info)
+
+		f(lwRsp)
+	}
+
+	return err
+}
+
+func (lw *innerListWatch) doParseDocumentToMongoInfo(fullDocument bson.Raw) (info MongoInfo) {
+	var err error
+
+	documentID := MongoDocument{}
+	err = bson.Unmarshal(fullDocument, &documentID)
+	if err != nil {
+		return
+	}
+
+	info.DocumentID = documentID.ID.Hex()
+
+	switch lw.Key {
+	case instance:
+		instance := Instance{}
+		err = bson.Unmarshal(fullDocument, &instance)
+		if err != nil {
+			log.Error("error to parse bson raw to documentInfo", err)
+			return
+		}
+		info.BusinessID = instance.InstanceInfo.InstanceId
+		info.Value = instance
+	case service:
+		service := Service{}
+		err := bson.Unmarshal(fullDocument, &service)
+		if err != nil {
+			log.Error("error to parse bson raw to documentInfo", err)
+			return
+		}
+		info.BusinessID = service.ServiceInfo.ServiceId
+		info.Value = service
+	default:
+		return
+	}
+	return
+}
+
+func (lw *innerListWatch) doParseWatchRspToMongoInfo(wRsp *MongoWatchResponse) (info MongoInfo) {
+	switch wRsp.OperationType {
+	case deleteOp:
+		//delete operation has no fullDocumentValue
+		info.DocumentID = wRsp.DocumentKey.ID.Hex()
+		return
+	case insertOp, updateOp, replaceOp:
+		return lw.doParseDocumentToMongoInfo(wRsp.FullDocument)
+	default:
+		log.Warn(fmt.Sprintf("unrecognized operation:%s", wRsp.OperationType))
+	}
+	return
+}

--- a/datasource/mongo/sd/listwatch_test.go
+++ b/datasource/mongo/sd/listwatch_test.go
@@ -1,0 +1,86 @@
+package sd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestListWatchConfig_String(t *testing.T) {
+	t.Run("TestListWatchConfig_String", func(t *testing.T) {
+		config := ListWatchConfig{
+			Timeout: 666,
+		}
+		ret := config.String()
+		assert.Equal(t, "{timeout: 666ns}", ret)
+	})
+	t.Run("when time is nil", func(t *testing.T) {
+		config := ListWatchConfig{}
+		ret := config.String()
+		assert.Equal(t, "{timeout: 0s}", ret)
+	})
+}
+
+func TestDoParseWatchRspToMongoInfo(t *testing.T) {
+	documentID := primitive.NewObjectID()
+
+	mockDocument, _ := bson.Marshal(bson.M{"_id": documentID, "domain": "default", "project": "default", "instanceinfo": bson.M{"instanceid": "8064a600438511eb8584fa163e8a81c9", "serviceid": "91afbe0faa9dc1594689139f099eb293b0cd048d",
+		"hostname": "ecs-hcsadlab-dev-0002", "status": "UP", "timestamp": "1608552622", "modtimestamp": "1608552622", "version": "0.0.1"}})
+
+	mockServiceDocument, _ := bson.Marshal(bson.M{"_id": documentID, "domain": "default", "project": "default", "serviceinfo": bson.M{"serviceid": "91afbe0faa9dc1594689139f099eb293b0cd048d", "timestamp": "1608552622", "modtimestamp": "1608552622", "version": "0.0.1"}})
+
+	// case instance insertOp
+
+	mockWatchRsp := &MongoWatchResponse{OperationType: insertOp,
+		FullDocument: mockDocument,
+		DocumentKey:  MongoDocument{ID: documentID},
+	}
+	ilw := innerListWatch{
+		Key: instance,
+	}
+	info := ilw.doParseWatchRspToMongoInfo(mockWatchRsp)
+	assert.Equal(t, documentID.Hex(), info.DocumentID)
+	assert.Equal(t, "8064a600438511eb8584fa163e8a81c9", info.BusinessID)
+
+	// case updateOp
+	mockWatchRsp.OperationType = updateOp
+	info = ilw.doParseWatchRspToMongoInfo(mockWatchRsp)
+	assert.Equal(t, documentID.Hex(), info.DocumentID)
+	assert.Equal(t, "8064a600438511eb8584fa163e8a81c9", info.BusinessID)
+	assert.Equal(t, "1608552622", info.Value.(Instance).InstanceInfo.ModTimestamp)
+
+	// case delete
+	mockWatchRsp.OperationType = deleteOp
+	info = ilw.doParseWatchRspToMongoInfo(mockWatchRsp)
+	assert.Equal(t, documentID.Hex(), info.DocumentID)
+	assert.Equal(t, "", info.BusinessID)
+
+	// case service insertOp
+	mockWatchRsp = &MongoWatchResponse{OperationType: insertOp,
+		FullDocument: mockServiceDocument,
+		DocumentKey:  MongoDocument{ID: primitive.NewObjectID()},
+	}
+	ilw.Key = service
+	info = ilw.doParseWatchRspToMongoInfo(mockWatchRsp)
+	assert.Equal(t, documentID.Hex(), info.DocumentID)
+	assert.Equal(t, "91afbe0faa9dc1594689139f099eb293b0cd048d", info.BusinessID)
+}
+
+func TestInnerListWatch_ResumeToken(t *testing.T) {
+	ilw := innerListWatch{
+		Key:         instance,
+		resumeToken: bson.Raw("resumToken"),
+	}
+	t.Run("get resume token test", func(t *testing.T) {
+		res := ilw.ResumeToken()
+		assert.NotNil(t, res)
+		assert.Equal(t, bson.Raw("resumToken"), res)
+	})
+
+	t.Run("set resume token test", func(t *testing.T) {
+		ilw.setResumeToken(bson.Raw("resumToken2"))
+		assert.Equal(t, ilw.resumeToken, bson.Raw("resumToken2"))
+	})
+}

--- a/datasource/mongo/sd/mongo_cache.go
+++ b/datasource/mongo/sd/mongo_cache.go
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"sync"
+
+	"github.com/apache/servicecomb-service-center/pkg/util"
+)
+
+// MongoCache implements Cache.
+// MongoCache is dedicated to stores service discovery data,
+// e.g. service, instance, lease.
+type MongoCache struct {
+	Options       *Options
+	name          string
+	store         map[string]interface{}
+	documentStore map[string]string
+	rwMux         sync.RWMutex
+	dirty         bool
+}
+
+func (c *MongoCache) Name() string {
+	return c.name
+}
+
+func (c *MongoCache) Size() (l int) {
+	c.rwMux.RLock()
+	l = int(util.Sizeof(c.store))
+	c.rwMux.RUnlock()
+	return
+}
+
+func (c *MongoCache) Get(id string) (v interface{}) {
+	c.rwMux.RLock()
+	if p, ok := c.store[id]; ok {
+		v = p
+	}
+	c.rwMux.RUnlock()
+	return
+}
+
+func (c *MongoCache) GetKeyByDocumentID(documentKey string) (id string) {
+	c.rwMux.RLock()
+	id = c.documentStore[documentKey]
+	c.rwMux.RUnlock()
+	return
+}
+
+func (c *MongoCache) GetDocumentIDByID(id string) (documentID string) {
+	c.rwMux.RLock()
+	for k, v := range c.documentStore {
+		if v == id {
+			documentID = k
+			break
+		}
+	}
+	c.rwMux.RUnlock()
+	return
+}
+
+func (c *MongoCache) Put(id string, v interface{}) {
+	c.rwMux.Lock()
+	c.store[id] = v
+	c.rwMux.Unlock()
+}
+
+func (c *MongoCache) PutDocumentID(id string, documentID string) {
+	c.rwMux.Lock()
+	c.documentStore[documentID] = id
+	c.rwMux.Unlock()
+}
+
+func (c *MongoCache) Remove(id string) {
+	c.rwMux.Lock()
+	delete(c.store, id)
+	c.rwMux.Unlock()
+}
+
+func (c *MongoCache) RemoveDocumentID(documentID string) {
+	c.rwMux.Lock()
+
+	delete(c.documentStore, documentID)
+
+	c.rwMux.Unlock()
+}
+
+func (c *MongoCache) MarkDirty() {
+	c.dirty = true
+}
+
+func (c *MongoCache) Dirty() bool { return c.dirty }
+
+func (c *MongoCache) Clear() {
+	c.rwMux.Lock()
+	c.dirty = false
+	c.store = make(map[string]interface{})
+	c.rwMux.Unlock()
+}
+
+func (c *MongoCache) ForEach(iter func(k string, v interface{}) (next bool)) {
+	c.rwMux.RLock()
+loopParent:
+	for k, v := range c.store {
+		if v == nil {
+			continue loopParent
+		}
+		if !iter(k, v) {
+			break loopParent
+		}
+	}
+	c.rwMux.RUnlock()
+}
+
+func NewMongoCache(name string, options *Options) *MongoCache {
+	return &MongoCache{
+		Options:       options,
+		name:          name,
+		store:         make(map[string]interface{}),
+		documentStore: make(map[string]string),
+	}
+}

--- a/datasource/mongo/sd/mongo_cacher_test.go
+++ b/datasource/mongo/sd/mongo_cacher_test.go
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/apache/servicecomb-service-center/pkg/gopool"
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func TestNewMongoCacher(t *testing.T) {
+	mockMongoCache := NewMongoCache("test", DefaultOptions())
+	w := &mockWatcher{}
+	lw := &mockListWatch{
+		Bus: make(chan *MongoListWatchResponse, 100),
+	}
+	w.lw = lw
+
+	cr := &MongoCacher{
+		Options:   DefaultOptions(),
+		ready:     make(chan struct{}),
+		lw:        lw,
+		goroutine: gopool.New(context.Background()),
+		cache:     mockMongoCache,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// case: cause list internal error before initialized
+	t.Run("case list: internal error before initialized", func(t *testing.T) {
+		cr.refresh(ctx)
+		if cr.IsReady() {
+			t.Fatalf("TestNewKvCacher failed")
+		}
+
+	})
+
+	// prepare mock data
+	var evt MongoEvent
+	cr = &MongoCacher{
+		Options: DefaultOptions().SetTable(instance).
+			SetEventFunc(func(e MongoEvent) {
+				evt = e
+			}),
+		ready:     make(chan struct{}),
+		lw:        lw,
+		goroutine: gopool.New(context.Background()),
+		cache:     mockMongoCache,
+	}
+	lw.Watcher = w
+
+	mockDocumentID := "5fcf2f1a4ea1e6d2f4c61d47"
+	mockBusinessID := "95cd8dbf3e8411eb92d8fa163e8a81c9"
+	mockResumeToken, _ :=
+		bson.Marshal(bson.M{"_data": "825FDB4272000000012B022C0100296E5A10043E2D15AC82D9484C8090E68AF36FED2A46645F696400645FD76265066A6D2DF2AAC8D80004"})
+
+	var mongoInfos []MongoInfo
+
+	data := MongoInfo{DocumentID: mockDocumentID, BusinessID: mockBusinessID,
+		Value: Instance{Domain: "default", Project: "default",
+			InstanceInfo: &pb.MicroServiceInstance{InstanceId: mockBusinessID, ModTimestamp: "100000"}}}
+
+	mongoInfos = append(mongoInfos, data)
+
+	test := &MongoListWatchResponse{
+		OperationType: insertOp,
+		Infos:         mongoInfos,
+	}
+
+	// case: list 1 resp and watch 0 event
+	t.Run("case list: first time list init cache", func(t *testing.T) {
+		// case: resume token is nil, first time list event is init
+		cr.cache.Remove(mockBusinessID)
+		cr.cache.RemoveDocumentID(mockDocumentID)
+		lw.resumeToken = nil
+		lw.ListResponse = test
+		lw.Bus <- nil
+
+		cr.refresh(ctx)
+
+		// check ready
+		assert.Equal(t, true, cr.IsReady())
+
+		//check config
+		assert.Equal(t, instance, cr.Options.Key)
+
+		// check event
+		if evt.Type != pb.EVT_INIT || evt.DocumentID != mockDocumentID || evt.BusinessID != mockBusinessID ||
+			evt.Value.(Instance).Domain != "default" || evt.Value.(Instance).Project != "default" {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" ||
+			cache.(Instance).InstanceInfo.ModTimestamp != "100000" {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+	})
+
+	t.Run("case list: re-list and updateOp cache", func(t *testing.T) {
+		// case: re-list and should be no event
+		lw.Bus <- nil
+		evt.Value = nil
+		cr.refresh(ctx)
+
+		//check events
+		assert.Equal(t, nil, evt.Value)
+
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" ||
+			cache.(Instance).InstanceInfo.ModTimestamp != "100000" {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+
+		// prepare updateOp data
+		dataUpdate := MongoInfo{DocumentID: mockDocumentID, BusinessID: mockBusinessID,
+			Value: Instance{Domain: "default", Project: "default",
+				InstanceInfo: &pb.MicroServiceInstance{InstanceId: mockBusinessID, HostName: "test", ModTimestamp: "100001"}}}
+
+		var mongoUpdateInfos []MongoInfo
+		mongoUpdateInfos = append(mongoUpdateInfos, dataUpdate)
+		testUpdate := &MongoListWatchResponse{
+			OperationType: insertOp,
+			Infos:         mongoUpdateInfos,
+		}
+
+		lw.ListResponse = testUpdate
+		lw.resumeToken = mockResumeToken
+
+		// case: re-list and over no event times, and then event should be updateOp
+		for i := 0; i < DefaultForceListInterval; i++ {
+			lw.Bus <- nil
+		}
+
+		evt.Value = nil
+		for i := 0; i < DefaultForceListInterval; i++ {
+			cr.refresh(ctx)
+		}
+		// check event
+		if evt.Type != pb.EVT_UPDATE || evt.DocumentID != mockDocumentID || evt.BusinessID != mockBusinessID ||
+			evt.Value.(Instance).Domain != "default" || evt.Value.(Instance).Project != "default" ||
+			evt.Value.(Instance).InstanceInfo.ModTimestamp != "100001" {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+		// check cache
+		cache = cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" ||
+			cache.(Instance).InstanceInfo.ModTimestamp != "100001" {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+	})
+
+	t.Run("case list: no infos list and delete cache", func(t *testing.T) {
+		// case: no infos list, event should be delete
+		lw.ListResponse = &MongoListWatchResponse{}
+		for i := 0; i < DefaultForceListInterval; i++ {
+			lw.Bus <- nil
+		}
+		evt.Value = nil
+		for i := 0; i < DefaultForceListInterval; i++ {
+			cr.refresh(ctx)
+		}
+
+		// check event
+		assert.Equal(t, pb.EVT_DELETE, evt.Type)
+
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		assert.Equal(t, nil, cache)
+	})
+
+	t.Run("case list: mark cache dirty and reset cache", func(t *testing.T) {
+		lw.ListResponse = test
+		lw.Bus <- nil
+		lw.resumeToken = nil
+		evt.Value = nil
+
+		cr.cache.MarkDirty()
+		cr.refresh(ctx)
+
+		// check event
+		if evt.Value != nil {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" {
+			t.Fatalf("TestNewMongoCacher failed:%s", test.OperationType)
+		}
+	})
+
+	t.Run("case watch: caught create event", func(t *testing.T) {
+		cr.cache.Remove(mockBusinessID)
+		cr.cache.RemoveDocumentID(mockDocumentID)
+		lw.Bus <- test
+		lw.Bus <- nil
+		lw.resumeToken = mockResumeToken
+
+		cr.refresh(ctx)
+
+		// check event
+		if evt.Type != pb.EVT_CREATE || evt.DocumentID != mockDocumentID || evt.BusinessID != mockBusinessID {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+	})
+
+	t.Run("case watch: caught updateOp event", func(t *testing.T) {
+		// prepare updateOp data
+		dataUpdate := MongoInfo{DocumentID: mockDocumentID, BusinessID: mockBusinessID,
+			Value: Instance{Domain: "default", Project: "default",
+				InstanceInfo: &pb.MicroServiceInstance{InstanceId: mockBusinessID, HostName: "test", ModTimestamp: "100001"}}}
+
+		var mongoUpdateInfos []MongoInfo
+		mongoUpdateInfos = append(mongoUpdateInfos, dataUpdate)
+		testUpdate := &MongoListWatchResponse{
+			OperationType: updateOp,
+			Infos:         mongoUpdateInfos,
+		}
+		lw.Bus <- testUpdate
+		lw.Bus <- nil
+
+		cr.refresh(ctx)
+		// check event
+		if evt.Type != pb.EVT_UPDATE || evt.DocumentID != mockDocumentID || evt.BusinessID != mockBusinessID ||
+			evt.Value.(Instance).Domain != "default" || evt.Value.(Instance).Project != "default" || evt.Value.(Instance).InstanceInfo.ModTimestamp != "100001" {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" || cache.(Instance).InstanceInfo.ModTimestamp != "100001" {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+	})
+
+	t.Run("case watch: caught delete event but value is nil", func(t *testing.T) {
+		test.OperationType = deleteOp
+		lw.Bus <- test
+		lw.Bus <- nil
+
+		cr.refresh(ctx)
+		// check event
+		if evt.Type != pb.EVT_DELETE || evt.DocumentID != mockDocumentID || evt.BusinessID != mockBusinessID ||
+			evt.Value.(Instance).Domain != "default" || evt.Value.(Instance).Project != "default" || evt.Value.(Instance).InstanceInfo.ModTimestamp != "100001" {
+			t.Fatalf("TestNewMongoCacher failed, %v", evt)
+		}
+		// check cache
+		cache := cr.cache.Get(mockBusinessID)
+		if cache != nil {
+			t.Fatalf("TestNewMongoCacher failed")
+		}
+
+	})
+}
+
+func TestMongoCacher_Run(t *testing.T) {
+
+	w := &mockWatcher{}
+	lw := &mockListWatch{
+		Bus: make(chan *MongoListWatchResponse, 100),
+	}
+
+	mockMongoCache := NewMongoCache("test", DefaultOptions())
+	cr := &MongoCacher{
+		Options:   DefaultOptions().SetTable(instance),
+		ready:     make(chan struct{}),
+		lw:        lw,
+		goroutine: gopool.New(context.Background()),
+		cache:     mockMongoCache,
+	}
+	lw.Watcher = w
+
+	cr.Run()
+
+	// check cache
+	cache := cr.cache
+	assert.NotNil(t, cache)
+
+	cr.Stop()
+}

--- a/datasource/mongo/sd/mongo_cacher_test.go
+++ b/datasource/mongo/sd/mongo_cacher_test.go
@@ -230,6 +230,7 @@ func TestNewMongoCacher(t *testing.T) {
 		if cache == nil || cache.(Instance).Domain != "default" || cache.(Instance).Project != "default" {
 			t.Fatalf("TestNewMongoCacher failed")
 		}
+
 	})
 
 	t.Run("case watch: caught updateOp event", func(t *testing.T) {

--- a/datasource/mongo/sd/options.go
+++ b/datasource/mongo/sd/options.go
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	DefaultTimeout       = 30 * time.Second
+	DefaultCacheInitSize = 100
+)
+
+type Options struct {
+	// Key is the table to unique specify resource type
+	Key      string
+	InitSize int
+	Timeout  time.Duration
+	Period   time.Duration
+	OnEvent  MongoEventFunc
+}
+
+func (options *Options) String() string {
+	return fmt.Sprintf("{key: %s, timeout: %s, period: %s}",
+		options.Key, options.Timeout, options.Period)
+}
+
+func (options *Options) SetTable(key string) *Options {
+	options.Key = key
+	return options
+}
+
+func (options *Options) SetEventFunc(f MongoEventFunc) *Options {
+	options.OnEvent = f
+	return options
+}
+
+func (options *Options) AppendEventFunc(f MongoEventFunc) *Options {
+	if prev := options.OnEvent; prev != nil {
+		next := f
+		f = func(evt MongoEvent) {
+			prev(evt)
+			next(evt)
+		}
+	}
+	options.OnEvent = f
+	return options
+}
+
+func DefaultOptions() *Options {
+	return &Options{
+		Key:      "",
+		Timeout:  DefaultTimeout,
+		Period:   time.Second,
+		InitSize: DefaultCacheInitSize,
+	}
+}

--- a/datasource/mongo/sd/options_test.go
+++ b/datasource/mongo/sd/options_test.go
@@ -1,0 +1,55 @@
+package sd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/go-chassis/cari/discovery"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptions(t *testing.T) {
+	options := Options{
+		Key: "",
+	}
+	assert.Empty(t, options, "config is empty")
+
+	options1 := options.SetTable("configKey")
+	assert.Equal(t, "configKey", options1.Key,
+		"contain key after method WithTable")
+
+	assert.Equal(t, 0, options1.InitSize,
+		"init size is zero")
+
+	mongoEventFunc = mongoEventFuncGet()
+	options1 = options.SetEventFunc(mongoEventFunc)
+	assert.NotNil(t, options1.OnEvent)
+
+	options1 = options.AppendEventFunc(mongoEventFuncGetOther())
+	assert.NotNil(t, options1.OnEvent)
+
+	out := options1.String()
+	assert.NotNil(t, out,
+		"method String return not after methods")
+}
+
+var mongoEventFunc MongoEventFunc
+
+func mongoEventFuncGet() MongoEventFunc {
+	fun := func(evt MongoEvent) {
+		evt.DocumentID = "DocumentID has changed"
+		evt.BusinessID = "BusinessID has changed"
+		evt.Value = 2
+		evt.Type = discovery.EVT_UPDATE
+		log.Info("in event func")
+	}
+	return fun
+}
+
+func mongoEventFuncGetOther() MongoEventFunc {
+	fun := func(evt MongoEvent) {
+		fmt.Print("math2")
+	}
+	return fun
+}

--- a/datasource/mongo/sd/types.go
+++ b/datasource/mongo/sd/types.go
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"time"
+
+	"github.com/go-chassis/cari/discovery"
+	pb "github.com/go-chassis/cari/discovery"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+const (
+	service  = "service"
+	instance = "instance"
+)
+
+var (
+	Types []string
+)
+
+func RegisterType(name string) {
+	Types = append(Types, name)
+}
+
+type MongoEvent struct {
+	DocumentID string
+	BusinessID string
+	Value      interface{}
+	Type       discovery.EventType
+}
+
+type MongoEventFunc func(evt MongoEvent)
+
+type MongoEventHandler interface {
+	Type() string
+	OnEvent(evt MongoEvent)
+}
+
+func NewMongoEventByMongoInf(info MongoInfo, action discovery.EventType) MongoEvent {
+	return MongoEvent{BusinessID: info.BusinessID, DocumentID: info.DocumentID, Value: info.Value, Type: action}
+}
+
+func NewMongoEvent(id string, documentID string, action discovery.EventType, v interface{}) MongoEvent {
+	event := MongoEvent{}
+	event.BusinessID = id
+	event.DocumentID = documentID
+	event.Type = action
+	event.Value = v
+	return event
+}
+
+type MongoListWatchResponse struct {
+	OperationType string
+	Infos         []MongoInfo
+}
+
+type MongoWatchResponse struct {
+	OperationType string
+	FullDocument  bson.Raw
+	DocumentKey   MongoDocument
+}
+
+type MongoDocument struct {
+	ID primitive.ObjectID `bson:"_id"`
+}
+
+type ResumeToken struct {
+	Data []byte `bson:"_data"`
+}
+
+type MongoInfo struct {
+	DocumentID string
+	BusinessID string
+	Value      interface{}
+}
+
+type Service struct {
+	Domain      string
+	Project     string
+	Tags        map[string]string
+	ServiceInfo *pb.MicroService
+}
+
+type Instance struct {
+	Domain       string
+	Project      string
+	RefreshTime  time.Time
+	InstanceInfo *pb.MicroServiceInstance
+}

--- a/datasource/mongo/sd/typestore.go
+++ b/datasource/mongo/sd/typestore.go
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// kv package provides a TypeStore to manage the implementations of sd package, see types.go
+package sd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/servicecomb-service-center/pkg/gopool"
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/apache/servicecomb-service-center/server/config"
+)
+
+var store = &TypeStore{}
+
+func init() {
+	store.Initialize()
+	registerInnerTypes()
+}
+
+type TypeStore struct {
+	caches    util.ConcurrentMap
+	ready     chan struct{}
+	goroutine *gopool.Pool
+	isClose   bool
+}
+
+func (s *TypeStore) Initialize() {
+	s.ready = make(chan struct{})
+	s.goroutine = gopool.New(context.Background())
+}
+
+func registerInnerTypes() {
+	RegisterType(service)
+	RegisterType(instance)
+}
+
+func (s *TypeStore) Run() {
+	s.goroutine.Do(s.store)
+	s.goroutine.Do(s.autoClearCache)
+}
+
+func (s *TypeStore) store(ctx context.Context) {
+	// new all types
+	for _, t := range Types {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.getOrCreateCache(t).Ready():
+		}
+	}
+	util.SafeCloseChan(s.ready)
+	log.Debug("all caches are ready")
+}
+
+func (s *TypeStore) autoClearCache(ctx context.Context) {
+	ttl := config.GetRegistry().CacheTTL
+
+	if ttl == 0 {
+		return
+	}
+
+	log.Info(fmt.Sprintf("start auto clear cache in %v", ttl))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(ttl):
+			for _, t := range Types {
+				cache := s.getOrCreateCache(t).Cache()
+				cache.MarkDirty()
+			}
+			log.Warn("caches are marked dirty!")
+		}
+	}
+}
+
+func (s *TypeStore) getOrCreateCache(t string) *MongoCacher {
+	cache, ok := s.caches.Get(t)
+	if ok {
+		return cache.(*MongoCacher)
+	}
+
+	options := DefaultOptions().SetTable(t)
+	EventProxy(t).InjectOptions(options)
+
+	cache = NewMongoCache(t, options)
+	cacher := NewMongoCacher(options, cache.(*MongoCache))
+	cacher.Run()
+
+	s.caches.Put(t, cacher)
+	return cacher
+}
+
+func (s *TypeStore) Stop() {
+	if s.isClose {
+		return
+	}
+	s.isClose = true
+
+	s.goroutine.Close(true)
+
+	util.SafeCloseChan(s.ready)
+
+	log.Debug("store daemon stopped")
+}
+
+func (s *TypeStore) Ready() <-chan struct{} {
+	return s.ready
+}
+
+func (s *TypeStore) TypeCacher(id string) *MongoCacher { return s.getOrCreateCache(id) }
+func (s *TypeStore) Service() *MongoCacher             { return s.TypeCacher(service) }
+func (s *TypeStore) Instance() *MongoCacher            { return s.TypeCacher(instance) }
+
+func Store() *TypeStore {
+	return store
+}

--- a/datasource/mongo/sd/typestore_test.go
+++ b/datasource/mongo/sd/typestore_test.go
@@ -1,0 +1,42 @@
+package sd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeStore_Initialize(t *testing.T) {
+	s := TypeStore{}
+	s.Initialize()
+	assert.NotNil(t, s.ready)
+	assert.NotNil(t, s.goroutine)
+	assert.Equal(t, false, s.isClose)
+}
+
+func TestTypeStore_Ready(t *testing.T) {
+	s := TypeStore{}
+	s.Initialize()
+	c := s.Ready()
+	assert.NotNil(t, c)
+}
+
+func TestTypeStore_Stop(t *testing.T) {
+	t.Run("when closed", func(t *testing.T) {
+		s := TypeStore{
+			isClose: true,
+		}
+		s.Initialize()
+		s.Stop()
+		assert.Equal(t, true, s.isClose)
+	})
+
+	t.Run("when not closed", func(t *testing.T) {
+		s := TypeStore{
+			isClose: false,
+		}
+		s.Initialize()
+		s.Stop()
+		assert.Equal(t, true, s.isClose)
+	})
+}

--- a/datasource/mongo/sd/watcher.go
+++ b/datasource/mongo/sd/watcher.go
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+type Watcher interface {
+	WatchResponse() <-chan *MongoListWatchResponse
+	Stop()
+}

--- a/datasource/mongo/sd/watcher_inner.go
+++ b/datasource/mongo/sd/watcher_inner.go
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sd
+
+import (
+	"context"
+	"sync"
+
+	"github.com/apache/servicecomb-service-center/pkg/gopool"
+	"github.com/apache/servicecomb-service-center/pkg/log"
+)
+
+type innerWatcher struct {
+	Cfg      ListWatchConfig
+	watchRsp chan *MongoListWatchResponse
+	stopCh   chan struct{}
+	stop     bool
+	mux      sync.Mutex
+	lw       ListWatch
+}
+
+func (w *innerWatcher) process(_ context.Context) {
+	stopCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(w.Cfg.Context, w.Cfg.Timeout)
+	gopool.Go(func(_ context.Context) {
+		defer close(stopCh)
+		_ = w.lw.DoWatch(ctx, w.sendWatchResponse)
+	})
+
+	select {
+	case <-stopCh:
+		// timed out or exception
+		w.Stop()
+		cancel()
+	case <-w.stopCh:
+		cancel()
+	}
+
+}
+
+func (w *innerWatcher) sendWatchResponse(resp *MongoListWatchResponse) {
+	defer log.Recover()
+	w.watchRsp <- resp
+}
+
+func (w *innerWatcher) WatchResponse() <-chan *MongoListWatchResponse {
+	return w.watchRsp
+}
+
+func (w *innerWatcher) Stop() {
+	w.mux.Lock()
+	if w.stop {
+		w.mux.Unlock()
+		return
+	}
+	w.stop = true
+	close(w.stopCh)
+	close(w.watchRsp)
+	w.mux.Unlock()
+}
+
+func newInnerWatcher(lw ListWatch, cfg ListWatchConfig) *innerWatcher {
+	iw := &innerWatcher{
+		Cfg:      cfg,
+		lw:       lw,
+		watchRsp: make(chan *MongoListWatchResponse, eventBusSize),
+		stopCh:   make(chan struct{}),
+	}
+	gopool.Go(iw.process)
+	return iw
+}

--- a/datasource/mongo/sd/watcher_test.go
+++ b/datasource/mongo/sd/watcher_test.go
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sd
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type mockWatcher struct {
+	lw *mockListWatch
+}
+
+func (w *mockWatcher) WatchResponse() <-chan *MongoListWatchResponse {
+	return w.lw.Bus
+}
+func (w *mockWatcher) Stop() {
+}
+
+type mockListWatch struct {
+	ListResponse *MongoListWatchResponse
+	Bus          chan *MongoListWatchResponse
+	Watcher      Watcher
+	resumeToken  bson.Raw
+}
+
+func (lw *mockListWatch) List(ListWatchConfig) (*MongoListWatchResponse, error) {
+	if lw.ListResponse == nil {
+		return nil, fmt.Errorf("error")
+	}
+	return lw.ListResponse, nil
+}
+
+func (lw *mockListWatch) DoWatch(ctx context.Context, f func(*MongoListWatchResponse)) error {
+	if lw.ListResponse == nil {
+		return fmt.Errorf("error")
+	}
+
+	f(lw.ListResponse)
+	<-ctx.Done()
+	return nil
+}
+func (lw *mockListWatch) Watch(ListWatchConfig) Watcher {
+	return lw.Watcher
+}
+
+func (lw *mockListWatch) ResumeToken() bson.Raw {
+	return lw.resumeToken
+}
+
+func TestInnerWatcher_EventBus(t *testing.T) {
+	w := newInnerWatcher(&mockListWatch{}, ListWatchConfig{Timeout: time.Second, Context: context.Background()})
+	resp := <-w.WatchResponse()
+	if resp != nil {
+		t.Fatal("TestInnerWatcher_EventBus failed")
+	}
+	w.Stop()
+
+	test := &MongoListWatchResponse{
+		OperationType: updateOp,
+	}
+	w = newInnerWatcher(&mockListWatch{ListResponse: test}, ListWatchConfig{Timeout: time.Second, Context: context.Background()})
+	resp = <-w.WatchResponse()
+	if resp == nil || resp.OperationType != updateOp {
+		t.Fatal("TestInnerWatcher_EventBus failed")
+	}
+	w.Stop()
+}

--- a/datasource/mongo/system.go
+++ b/datasource/mongo/system.go
@@ -21,11 +21,17 @@ import (
 	"context"
 
 	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/etcd/path"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
 	"github.com/apache/servicecomb-service-center/pkg/dump"
+	"github.com/apache/servicecomb-service-center/pkg/gopool"
 )
 
 func (ds *DataSource) DumpCache(ctx context.Context, cache *dump.Cache) {
-
+	gopool.New(ctx, gopool.Configure().Workers(2)).
+		Do(func(_ context.Context) { setServiceValue(sd.Store().Service(), &cache.Microservices) }).
+		Do(func(_ context.Context) { setInstanceValue(sd.Store().Instance(), &cache.Instances) }).
+		Done()
 }
 
 func (ds *DataSource) DLock(ctx context.Context, request *datasource.DLockRequest) error {
@@ -34,4 +40,24 @@ func (ds *DataSource) DLock(ctx context.Context, request *datasource.DLockReques
 
 func (ds *DataSource) DUnlock(ctx context.Context, request *datasource.DUnlockRequest) error {
 	return nil
+}
+
+func setServiceValue(e *sd.MongoCacher, setter dump.Setter) {
+	e.Cache().ForEach(func(k string, kv interface{}) (next bool) {
+		setter.SetValue(&dump.KV{
+			Key:   path.GenerateServiceKey(kv.(sd.Service).Domain+path.SPLIT+kv.(sd.Service).Project, k),
+			Value: kv.(sd.Service).ServiceInfo,
+		})
+		return true
+	})
+}
+
+func setInstanceValue(e *sd.MongoCacher, setter dump.Setter) {
+	e.Cache().ForEach(func(k string, kv interface{}) (next bool) {
+		setter.SetValue(&dump.KV{
+			Key:   path.GenerateInstanceKey(kv.(sd.Instance).Domain+path.SPLIT+kv.(sd.Instance).Project, kv.(sd.Instance).InstanceInfo.ServiceId, k),
+			Value: kv.(sd.Instance).InstanceInfo,
+		})
+		return true
+	})
 }

--- a/datasource/mongo/system_test.go
+++ b/datasource/mongo/system_test.go
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"testing"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/mongo"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
+	"github.com/apache/servicecomb-service-center/pkg/dump"
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/go-chassis/v2/storage"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func init() {
+	config := storage.Options{
+		URI: "mongodb://localhost:27017",
+	}
+	client.NewMongoClient(config)
+	// clean the mongodb
+	client.GetMongoClient().Delete(getContext(), mongo.CollectionInstance, bson.M{})
+	client.GetMongoClient().Delete(getContext(), mongo.CollectionService, bson.M{})
+}
+
+func TestDumpCache(t *testing.T) {
+	var store = &sd.TypeStore{}
+	store.Initialize()
+	cache := new(dump.Cache)
+	t.Run("Register service && instance, check dump, should pass", func(t *testing.T) {
+		var serviceID string
+		service, err := datasource.Instance().RegisterService(getContext(), &pb.CreateServiceRequest{
+			Service: &pb.MicroService{
+				ServiceName: "create_service_test",
+				AppId:       "create_service_appId",
+				Version:     "1.0.0",
+				Level:       "BACK",
+				Status:      pb.MS_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, service.Response.GetCode())
+		serviceID = service.ServiceId
+
+		instance, err := datasource.Instance().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
+			Instance: &pb.MicroServiceInstance{
+				ServiceId: serviceID,
+				Endpoints: []string{
+					"localhost://127.0.0.1:8080",
+				},
+				HostName: "HOST_TEST",
+				Status:   pb.MSI_UP,
+			},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, pb.ResponseSuccess, instance.Response.GetCode())
+
+		datasource.Instance().DumpCache(getContext(), cache)
+		assert.NotNil(t, cache)
+	})
+}

--- a/syncer/server/handler.go
+++ b/syncer/server/handler.go
@@ -46,8 +46,6 @@ func (s *Server) tickHandler() {
 		return
 	}
 	log.Debugf("Handle Tick")
-	// Flush data to the storage of servicecenter
-	s.servicecenter.FlushData()
 
 	// sends a UserEvent on Serf, the event will be broadcast between members
 	s.mux.Lock()
@@ -200,6 +198,9 @@ func (s *Server) incrementUserEvent(data ...[]byte) (success bool) {
 }
 
 func (s *Server) notifyUserEvent(data ...[]byte) (success bool) {
+	// Flush data to the storage of servicecenter
+	s.servicecenter.FlushData()
+
 	err := s.serf.UserEvent(EventDiscovered, util.StringToBytesWithNoCopy(s.conf.Cluster))
 	if err != nil {
 		log.Error("Syncer send discovered user event failed", err)

--- a/syncer/servicecenter/servicecenter.go
+++ b/syncer/servicecenter/servicecenter.go
@@ -90,7 +90,6 @@ func (s *servicecenter) Registry(clusterName string, data *pb.SyncData) {
 
 		// If the svc is in the mapping, just do nothing, if not, created it in servicecenter and get the new serviceID
 		svcID := s.createService(svc)
-		log.Debugf("create service success orgServiceID= %s, curServiceID = %s", inst.ServiceId, svcID)
 
 		// If inst is in the mapping, just heart beat it in servicecenter
 		log.Debugf("trying to do registration of instance, instanceID = %s", inst.InstanceId)
@@ -136,10 +135,6 @@ func (s *servicecenter) IncrementRegistry(clusterName string, data *pb.SyncData)
 			continue
 		}
 
-		// If the svc is in the mapping, just do nothing, if not, created it in servicecenter and get the new serviceID
-		svcID := s.createService(svc)
-		log.Debug(fmt.Sprintf("create service success orgServiceID= %s, curServiceID = %s", inst.ServiceId, svcID))
-
 		matches := pb.Expansions(inst.Expansions).Find("action", map[string]string{})
 		if len(matches) != 1 {
 			err := utils.ErrActionInvalid
@@ -149,6 +144,9 @@ func (s *servicecenter) IncrementRegistry(clusterName string, data *pb.SyncData)
 		action := string(matches[0].Bytes[:])
 
 		if action == string(discovery.EVT_CREATE) {
+			// If the svc is in the mapping, just do nothing, if not, created it in servicecenter and get the new serviceID
+			svcID := s.createService(svc)
+
 			log.Debug(fmt.Sprintf("trying to do registration of instance, instanceID = %s", inst.InstanceId))
 
 			// If inst is in the mapping, just heart beat it in servicecenter

--- a/syncer/servicecenter/sync.go
+++ b/syncer/servicecenter/sync.go
@@ -19,6 +19,7 @@ package servicecenter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	pb "github.com/apache/servicecomb-service-center/syncer/proto"
@@ -42,7 +43,11 @@ func (s *servicecenter) heartbeatInstances(mapping pb.SyncMapping, instance *pb.
 
 func (s *servicecenter) createService(service *pb.SyncService) string {
 	ctx := context.Background()
-	serviceID, _ := s.servicecenter.ServiceExistence(ctx, service.DomainProject, service)
+	serviceID, err := s.servicecenter.ServiceExistence(ctx, service.DomainProject, service)
+	if err != nil {
+		log.Error("get service existence failed", err)
+	}
+
 	if serviceID == "" {
 		var err error
 		serviceID, err = s.servicecenter.CreateService(ctx, service.DomainProject, service)
@@ -51,6 +56,8 @@ func (s *servicecenter) createService(service *pb.SyncService) string {
 			return ""
 		}
 		log.Debugf("Create service successful, serviceID = %s", serviceID)
+	} else {
+		log.Debug(fmt.Sprintf("service already exists, serviceID = %s", serviceID))
 	}
 	return serviceID
 }


### PR DESCRIPTION
dumpcache接口实现以及syncer代码优化

    1.实现mongo的dumpcache接口
    2.syncer逻辑优化
    3.existence接口请求bug修复
