### PR TITLE
SC event sync

### DIFF
--- a/datasource/mongo/event/event.go
+++ b/datasource/mongo/event/event.go
@@ -15,14 +15,15 @@
  * limitations under the License.
  */
 
-package bootstrap
+package event
 
 import (
-	_ "github.com/apache/servicecomb-service-center/datasource/mongo"
-
-	// heartbeat
-	_ "github.com/apache/servicecomb-service-center/datasource/mongo/heartbeat/heartbeatchecker"
-
-	// events
-	_ "github.com/apache/servicecomb-service-center/datasource/mongo/event"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
+	"github.com/apache/servicecomb-service-center/pkg/log"
 )
+
+func init() {
+	log.Info("event init")
+	instanceEventHandler := NewInstanceEventHandler()
+	sd.EventProxy(instanceEventHandler.Type()).AddHandleFunc(instanceEventHandler.OnEvent)
+}

--- a/datasource/mongo/event/instance_event_handler.go
+++ b/datasource/mongo/event/instance_event_handler.go
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package event
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/mongo"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
+	"github.com/apache/servicecomb-service-center/pkg/dump"
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/apache/servicecomb-service-center/server/syncernotify"
+	"github.com/go-chassis/cari/discovery"
+)
+
+const (
+	SPLIT           = "/"
+	ServiceRootKey  = "/cse-sr/ms/files"
+	InstanceRootKey = "/cse-sr/inst/files"
+)
+
+// InstanceEventHandler is the handler to handle events
+//as instance registry or instance delete, and notify syncer
+type InstanceEventHandler struct {
+}
+
+func (h InstanceEventHandler) Type() string {
+	return mongo.CollectionInstance
+}
+
+func (h InstanceEventHandler) OnEvent(evt sd.MongoEvent) {
+	action := evt.Type
+	instance := evt.Value.(sd.Instance)
+	providerID := instance.InstanceInfo.ServiceId
+	providerInstanceID := instance.InstanceInfo.InstanceId
+
+	cacheService := sd.Store().Service().Cache().Get(providerID)
+	var ms *discovery.MicroService
+	if cacheService != nil {
+		ms = cacheService.(sd.Service).ServiceInfo
+	}
+	if ms == nil {
+		log.Info("get cached service failed, then get from data base")
+		service, errs := mongo.GetService(context.Background(), bson.M{"serviceinfo.serviceid": providerID})
+		if service == nil || errs != nil {
+			log.Error("get service from database failed", errs)
+			return
+		}
+		ms = service.ServiceInfo // service in the cache may not ready, query from db once
+		if ms == nil {
+			log.Warn(fmt.Sprintf("caught [%s] instance[%s/%s] event, endpoints %v, get provider's file failed from db\n",
+				action, providerID, providerInstanceID, instance.InstanceInfo.Endpoints))
+			return
+		}
+	}
+	if !syncernotify.GetSyncerNotifyCenter().Closed() {
+		NotifySyncerInstanceEvent(evt, ms)
+	}
+}
+
+func NewInstanceEventHandler() *InstanceEventHandler {
+	return &InstanceEventHandler{}
+}
+
+func NotifySyncerInstanceEvent(evt sd.MongoEvent, ms *discovery.MicroService) {
+	instance := evt.Value.(sd.Instance).InstanceInfo
+	log.Info(fmt.Sprintf("instanceId in NotifySyncerInstanceEvent : %v, the serviceId : %v", instance.InstanceId, instance.ServiceId))
+	instanceKey := util.StringJoin([]string{datasource.InstanceKeyPrefix, evt.Value.(sd.Instance).Domain,
+		evt.Value.(sd.Instance).Project, instance.ServiceId, instance.InstanceId}, datasource.SPLIT)
+
+	instanceKv := dump.KV{
+		Key:   instanceKey,
+		Value: instance,
+	}
+
+	dumpInstance := dump.Instance{
+		KV:    &instanceKv,
+		Value: instance,
+	}
+	serviceKey := util.StringJoin([]string{datasource.ServiceKeyPrefix, evt.Value.(sd.Instance).Domain,
+		evt.Value.(sd.Instance).Project, instance.ServiceId}, datasource.SPLIT)
+	serviceKv := dump.KV{
+		Key:   serviceKey,
+		Value: ms,
+	}
+
+	dumpService := dump.Microservice{
+		KV:    &serviceKv,
+		Value: ms,
+	}
+
+	instEvent := &dump.WatchInstanceChangedEvent{
+		Action:   string(evt.Type),
+		Service:  &dumpService,
+		Instance: &dumpInstance,
+	}
+	syncernotify.GetSyncerNotifyCenter().AddEvent(instEvent)
+
+	log.Debug(fmt.Sprintf("success to add instance change event with adtion [%s], instanceKey : %s to event queue", instEvent.Action, instanceKey))
+}

--- a/datasource/mongo/event/instance_event_handler_test.go
+++ b/datasource/mongo/event/instance_event_handler_test.go
@@ -1,0 +1,76 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
+	"github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/go-chassis/v2/storage"
+)
+
+func init() {
+	config := storage.Options{
+		URI: "mongodb://localhost:27017",
+	}
+	client.NewMongoClient(config)
+}
+
+func TestInstanceEventHandler_OnEvent(t *testing.T) {
+
+	t.Run("OnEvent test by request config", func(t *testing.T) {
+		h := InstanceEventHandler{}
+		h.OnEvent(mongoAssign())
+		assert.NotNil(t, discovery.MicroService{})
+	})
+	t.Run("OnEvent test by request config", func(t *testing.T) {
+		h := InstanceEventHandler{}
+		h.OnEvent(mongoAssign())
+		assert.Error(t, assert.AnError)
+	})
+}
+
+func TestNotifySyncerInstanceEvent(t *testing.T) {
+	t.Run("NotifySyncerInstanceEvent test", func(t *testing.T) {
+		mongoEvent := mongoAssign()
+		microService := getMicroService()
+		NotifySyncerInstanceEvent(mongoEvent, microService)
+		assert.Equal(t, false, t.Failed())
+	})
+}
+
+func mongoAssign() sd.MongoEvent {
+	sd.Store().Service().Cache()
+	endPoints := []string{"127.0.0.1:27017"}
+	instance := discovery.MicroServiceInstance{
+		InstanceId: "f73dceb440f711eba63ffa163e7cdcb8",
+		ServiceId:  "2a20507274fc71c925d138341517dce14b600744",
+		Endpoints:  endPoints,
+	}
+	mongoInstance := sd.Instance{}
+	mongoInstance.InstanceInfo = &instance
+	mongoInstance.Domain = "default"
+	mongoInstance.Project = "default"
+	mongoEvent := sd.MongoEvent{}
+	mongoEvent.DocumentID = "5fdc483b4a885f69317e3505"
+	mongoEvent.Value = mongoInstance
+	mongoEvent.Type = discovery.EVT_CREATE
+	mongoEvent.ResourceID = "f73dceb440f711eba63ffa163e7cdcb8"
+	return mongoEvent
+}
+
+func getMicroService() *discovery.MicroService {
+	microService := discovery.MicroService{
+		ServiceId:    "1efe8be8eacce1efbf67967978133572fb8b5667",
+		AppId:        "default",
+		ServiceName:  "ProviderDemoService1-2",
+		Version:      "1.0.0",
+		Level:        "BACK",
+		Status:       "UP",
+		Timestamp:    "1608260891",
+		ModTimestamp: "1608260891",
+	}
+	return &microService
+}


### PR DESCRIPTION
1.删除读取配置文件的代码，采用系统自带mongo配置。
2.调用公共变量拼接key。
3.删除notify状态检查及操作。
