### PR TITLE
Update Mongo DumpCache Interface

### DIFF
--- a/datasource/mongo/system.go
+++ b/datasource/mongo/system.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/servicecomb-service-center/pkg/dump"
 	"github.com/apache/servicecomb-service-center/pkg/gopool"
 	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/patrickmn/go-cache"
 )
 
 func (ds *DataSource) DumpCache(ctx context.Context) *dump.Cache {
@@ -46,10 +47,11 @@ func (ds *DataSource) DUnlock(ctx context.Context, request *datasource.DUnlockRe
 
 func setServiceValue(e *sd.MongoCacher, setter dump.Setter) {
 	e.Cache().ForEach(func(k string, kv interface{}) (next bool) {
+		service := kv.(cache.Item).Object.(sd.Service)
 		setter.SetValue(&dump.KV{
-			Key: util.StringJoin([]string{datasource.ServiceKeyPrefix, kv.(sd.Service).Domain,
-				kv.(sd.Service).Project, k}, datasource.SPLIT),
-			Value: kv.(sd.Service).ServiceInfo,
+			Key: util.StringJoin([]string{datasource.ServiceKeyPrefix, service.Domain, service.Project, k},
+				datasource.SPLIT),
+			Value: service.ServiceInfo,
 		})
 		return true
 	})
@@ -57,10 +59,11 @@ func setServiceValue(e *sd.MongoCacher, setter dump.Setter) {
 
 func setInstanceValue(e *sd.MongoCacher, setter dump.Setter) {
 	e.Cache().ForEach(func(k string, kv interface{}) (next bool) {
+		instance := kv.(cache.Item).Object.(sd.Instance)
 		setter.SetValue(&dump.KV{
-			Key: util.StringJoin([]string{datasource.InstanceKeyPrefix, kv.(sd.Instance).Domain,
-				kv.(sd.Instance).Project, kv.(sd.Instance).InstanceInfo.ServiceId, k}, datasource.SPLIT),
-			Value: kv.(sd.Instance).InstanceInfo,
+			Key: util.StringJoin([]string{datasource.InstanceKeyPrefix, instance.Domain, instance.Project,
+				instance.InstanceInfo.ServiceId, k}, datasource.SPLIT),
+			Value: instance.InstanceInfo,
 		})
 		return true
 	})

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/openzipkin/zipkin-go-opentracing v0.3.3-0.20180123190626-6bb822a7f15f
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v0.9.1
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4


### PR DESCRIPTION
mongo缓存用go-cache重构实现后变更了foreach方法，因此更新DumpCache接口
