### PR TITLE
修复同步时无法生成service问题

### DIFF
--- a/syncer/servicecenter/sync.go
+++ b/syncer/servicecenter/sync.go
@@ -45,8 +45,7 @@ func (s *servicecenter) createService(service *pb.SyncService) (string, error) {
 	ctx := context.Background()
 	serviceID, err := s.servicecenter.ServiceExistence(ctx, service.DomainProject, service)
 	if err != nil {
-		log.Error("get service existence failed", err)
-		return "", err
+		log.Warn(fmt.Sprintf("get service existence failed %s", err))
 	}
 
 	if serviceID == "" {


### PR DESCRIPTION
实例同步时SC会先http请求查看同步实例对应的service是否存在，service不存在时http请求错误，若此时return，service将不会创建导致同步失败。