### PR TITLE
[SCB-2094]Mongo supports CA certificate verification

### DIFF
--- a/datasource/mongo/client/common.go
+++ b/datasource/mongo/client/common.go
@@ -22,4 +22,5 @@ import (
 var (
 	ErrCollectionsNil = errors.New("collection is nil")
 	ErrOpenDbFailed   = errors.New("open db failed")
+	ErrRootCAMissing  = errors.New("rootCAFile is empty in config file")
 )

--- a/datasource/mongo/mongo.go
+++ b/datasource/mongo/mongo.go
@@ -86,8 +86,13 @@ func (ds *DataSource) initPlugins() error {
 }
 
 func (ds *DataSource) initClient() error {
-	uri := config.GetString("registry.mongo.cluster.uri", "mongodb://localhost:27017", config.WithStandby("manager_cluster"))
-	cfg := storage.NewConfig(uri)
+	uri := config.GetString("registry.mongo.cluster.uri", "mongodb://localhost:27017")
+	sslEnable := config.GetBool("registry.mongo.cluster.sslEnabled", false)
+	rootCA := config.GetString("registry.mongo.cluster.rootCAFile", "/opt/ssl/ca.crt")
+	verifyPeer := config.GetBool("registry.mongo.cluster.verifyPeer", false)
+	certFile := config.GetString("registry.mongo.cluster.certFile", "")
+	keyFile := config.GetString("registry.mongo.cluster.keyFile", "")
+	cfg := storage.NewConfig(uri, storage.SSLEnabled(sslEnable), storage.RootCA(rootCA), storage.VerifyPeer(verifyPeer), storage.CertFile(certFile), storage.KeyFile(keyFile))
 	client.NewMongoClient(cfg)
 	select {
 	case err := <-client.GetMongoClient().Err():

--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -96,6 +96,11 @@ registry:
       timeout: 10
     cluster:
       uri: mongodb://localhost:27017
+      sslEnabled: false
+      rootCAFile: /opt/ssl/ca.crt
+      verifyPeer: false
+      certFile: /opt/ssl/client.crt
+      keyFile: /opt/ssl/client.key
 
   service:
     # enable the job clear the microservices which deploy no instance

--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-chassis/cari v0.0.2-0.20210208095358-3bccdf2ce456
 	github.com/go-chassis/foundation v0.2.2
-	github.com/go-chassis/go-archaius v1.3.6-0.20201130023516-387922b408d0
-	github.com/go-chassis/go-chassis/v2 v2.1.1-0.20201208095114-93feb76fd997
+	github.com/go-chassis/go-archaius v1.3.6-0.20201210061741-7450779aaeb8
+	github.com/go-chassis/go-chassis/v2 v2.1.1-0.20210218100404-85e04ad6bd31
 	github.com/go-chassis/kie-client v0.0.0-20210122061843-eee856b0a9af
 	github.com/golang/protobuf v1.4.2
 	github.com/gorilla/websocket v1.4.2
@@ -34,6 +34,7 @@ require (
 	github.com/karlseguin/expect v1.0.7 // indirect
 	github.com/labstack/echo/v4 v4.1.18-0.20201218141459-936c48a17e97
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/natefinch/lumberjack v0.0.0-20170531160350-a96e63847dc3
 	github.com/olekukonko/tablewriter v0.0.0-20180506121414-d4647c9c7a84
 	github.com/onsi/ginkgo v1.14.0

--- a/scripts/build/local.sh
+++ b/scripts/build/local.sh
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 set -e
-export GOPROXY=https://goproxy.io
 export GOOS=${1:-"linux"}
 export GOARCH=${4:-"amd64"}
 export CGO_ENABLED=${CGO_ENABLED:-0} # prevent to compile cgo file


### PR DESCRIPTION
【issue】: #857
【特性/模块名称】：db为mongo支持CA证书校验
【修改内容】：db为mongo支持CA证书校验
【自测情况】：ut全部通过

【说明】
mongo的[server配置](https://docs.mongodb.com/v4.0/tutorial/configure-ssl/) 

1. client需要CA证书校验，mongo启动配置
![image](https://user-images.githubusercontent.com/27326092/108353144-bff6a900-7222-11eb-9df5-871c77c75c27.png)
sc的yaml配置中certFile与keyFile可以为空如下图
![image](https://user-images.githubusercontent.com/27326092/108353312-f6ccbf00-7222-11eb-8aa5-459980b5055a.png)

2. 判断client证书的有效性，mongo启动配置
![image](https://user-images.githubusercontent.com/27326092/108353615-52974800-7223-11eb-8ab4-a8fc71c4850e.png)
sc的yaml配置全不能为空如下图
![image](https://user-images.githubusercontent.com/27326092/108353780-7ce90580-7223-11eb-82c7-28863fe1f05f.png)

3. 若想调过证书验证（即sc的yaml配置中certFile与keyFile可以为空），mongo启动配置如下
![image](https://user-images.githubusercontent.com/27326092/108353866-9722e380-7223-11eb-82d6-b3f38a7e80ee.png)



