### PR TITLE
[SCB-2094] Bugfix-cache heartbeat mode in mongo

### DIFF
--- a/datasource/mongo/heartbeat/cache/heartbeatcache.go
+++ b/datasource/mongo/heartbeat/cache/heartbeatcache.go
@@ -29,6 +29,14 @@ import (
 	"github.com/apache/servicecomb-service-center/pkg/util"
 )
 
+const (
+	maxInterval     = 60
+	minInterval     = 0
+	defaultInterval = 30
+	maxTimes        = 3
+	minTimes        = 0
+)
+
 var ErrHeartbeatConversionFailed = errors.New("instanceHeartbeatInfo type conversion failed. ")
 
 func init() {
@@ -91,6 +99,13 @@ func notInCacheStrategy(ctx context.Context, request *pb.HeartbeatRequest) (*pb.
 		return resp, err
 	}
 	interval, times := instance.Instance.HealthCheck.Interval, instance.Instance.HealthCheck.Times
+	// Set the range of interval and time
+	if interval > maxInterval || interval < minTimes {
+		interval = defaultInterval
+	}
+	if times > maxTimes || times < minTimes {
+		times = maxTimes
+	}
 	err = addHeartbeatTask(request.ServiceId, request.InstanceId, interval*(times+1))
 	if err != nil {
 		log.Error(fmt.Sprintf("heartbeat failed, instance[%s]. operator %s", request.InstanceId, remoteIP), err)

--- a/datasource/mongo/mongo.go
+++ b/datasource/mongo/mongo.go
@@ -31,6 +31,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const defaultExpireTime = 300
+
 func init() {
 	datasource.Install("mongo", NewDataSource)
 }
@@ -139,7 +141,7 @@ func EnsureInstance() {
 	wrapCreateCollectionError(err)
 
 	instanceIndex := BuildIndexDoc(ColumnRefreshTime)
-	instanceIndex.Options = options.Index().SetExpireAfterSeconds(60)
+	instanceIndex.Options = options.Index().SetExpireAfterSeconds(defaultExpireTime)
 
 	instanceServiceIndex := BuildIndexDoc(StringBuilder([]string{ColumnInstance, ColumnServiceID}))
 


### PR DESCRIPTION
【issue】: #845
【特性/模块名称】：mongo支持缓存心跳模式
【修改内容】：

1.  db 为 mongo 时，sc 启动自身未发送心跳接口未实现
2.  cache 心跳模式，若interval超过 60 或小于 0 时，默认设置为 60；若times超过3或小于0时，默认设置为 3
3.  mongo的instance表refresh_time的超时时间设置为 300s

【自测情况】：ut全部通过