### PR TITLE
add context

### DIFF
--- a/server/plugin/quota/buildin/buildin.go
+++ b/server/plugin/quota/buildin/buildin.go
@@ -39,7 +39,7 @@ func New() mgr.Instance {
 type Quota struct {
 }
 
-func (q *Quota) GetQuota(t quota.ResourceType) int64 {
+func (q *Quota) GetQuota(ctx context.Context, t quota.ResourceType) int64 {
 	switch t {
 	case quota.TypeInstance:
 		return int64(quota.DefaultInstanceQuota)

--- a/server/plugin/quota/quota.go
+++ b/server/plugin/quota/quota.go
@@ -89,7 +89,7 @@ func NewApplyQuotaResource(quotaType ResourceType, domainProject, serviceID stri
 
 type Manager interface {
 	RemandQuotas(ctx context.Context, quotaType ResourceType)
-	GetQuota(t ResourceType) int64
+	GetQuota(ctx context.Context, t ResourceType) int64
 }
 
 type ResourceType int
@@ -119,7 +119,7 @@ func Apply(ctx context.Context, res *ApplyQuotaResource) *pb.Error {
 		return pb.NewError(pb.ErrInternal, err.Error())
 	}
 
-	limitQuota := plugin.Plugins().Instance(QUOTA).(Manager).GetQuota(res.QuotaType)
+	limitQuota := plugin.Plugins().Instance(QUOTA).(Manager).GetQuota(ctx, res.QuotaType)
 	curNum, err := GetResourceUsage(ctx, res)
 	if err != nil {
 		log.Errorf(err, "%s quota check failed", res.QuotaType)


### PR DESCRIPTION
配额管理需要支持context管理，可能有的插件实现需要判断上下文，来返回配额限制