### PR TITLE
self preservation can not replay events

### DIFF
--- a/datasource/etcd/sd/etcd/cacher_kv.go
+++ b/datasource/etcd/sd/etcd/cacher_kv.go
@@ -373,6 +373,7 @@ func (c *KvCacher) handleDeferEvents(ctx context.Context) {
 			return
 		case evt, ok := <-c.Cfg.DeferHandler.HandleChan():
 			if !ok {
+				log.Error("replay channel is closed", nil)
 				return
 			}
 

--- a/pkg/metrics/common.go
+++ b/pkg/metrics/common.go
@@ -23,7 +23,15 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-func getValue(name string, labels prometheus.Labels, apply func(m *dto.Metric) float64) float64 {
+// keys of gauge
+const (
+	KeyServiceTotal  = "service_total"
+	KeyInstanceTotal = "instance_total"
+
+	SubSystem = "db"
+)
+
+func getValue(name string, labels prometheus.Labels) float64 {
 	f := Family(name)
 	if f == nil {
 		return 0
@@ -34,13 +42,13 @@ func getValue(name string, labels prometheus.Labels, apply func(m *dto.Metric) f
 		if !matchAll && !MatchLabels(m, labels) {
 			continue
 		}
-		sum += apply(m)
+		sum += m.GetGauge().GetValue()
 	}
 	return sum
 }
 
 func GaugeValue(name string, labels prometheus.Labels) int64 {
-	return int64(getValue(name, labels, func(m *dto.Metric) float64 { return m.GetGauge().GetValue() }))
+	return int64(getValue(name, labels))
 }
 
 func MatchLabels(m *dto.Metric, labels prometheus.Labels) bool {

--- a/server/config/util.go
+++ b/server/config/util.go
@@ -73,6 +73,9 @@ func GetInt(key string, def int, opts ...Option) int {
 	if archaius.Exist(key) {
 		return archaius.GetInt(key, def)
 	}
+	if archaius.Exist(options.Standby) {
+		return archaius.GetInt(options.Standby, def)
+	}
 	return beego.AppConfig.DefaultInt(options.Standby, def)
 }
 

--- a/server/metrics/meta.go
+++ b/server/metrics/meta.go
@@ -18,6 +18,7 @@
 package metrics
 
 import (
+	"strings"
 	"time"
 
 	"github.com/apache/servicecomb-service-center/pkg/metrics"
@@ -29,24 +30,20 @@ import (
 // keys of gauge
 const (
 	KeyDomainTotal    = "domain_total"
-	KeyServiceTotal   = "service_total"
-	KeyInstanceTotal  = "instance_total"
 	KeySchemaTotal    = "schema_total"
 	KeyFrameworkTotal = "framework_total"
-
-	SubSystem = "db"
 )
 
 // Key return metrics key
 func Key(name string) string {
-	return util.StringJoin([]string{SubSystem, name}, "_")
+	return util.StringJoin([]string{metrics.SubSystem, name}, "_")
 }
 
 var (
 	domainCounter = helper.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.FamilyName,
-			Subsystem: SubSystem,
+			Subsystem: metrics.SubSystem,
 			Name:      KeyDomainTotal,
 			Help:      "Gauge of domain created in Service Center",
 		}, []string{"instance"})
@@ -55,22 +52,22 @@ var (
 		prometheus.GaugeOpts{
 			Namespace: metrics.FamilyName,
 			Subsystem: "db",
-			Name:      KeyServiceTotal,
+			Name:      metrics.KeyServiceTotal,
 			Help:      "Gauge of microservice created in Service Center",
 		}, []string{"instance", "framework", "frameworkVersion", "domain"})
 
 	instanceCounter = helper.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.FamilyName,
-			Subsystem: SubSystem,
-			Name:      KeyInstanceTotal,
+			Subsystem: metrics.SubSystem,
+			Name:      metrics.KeyInstanceTotal,
 			Help:      "Gauge of microservice created in Service Center",
 		}, []string{"instance", "domain"})
 
 	schemaCounter = helper.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.FamilyName,
-			Subsystem: SubSystem,
+			Subsystem: metrics.SubSystem,
 			Name:      KeySchemaTotal,
 			Help:      "Gauge of schema created in Service Center",
 		}, []string{"instance", "domain"})
@@ -78,7 +75,7 @@ var (
 	frameworkCounter = helper.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.FamilyName,
-			Subsystem: SubSystem,
+			Subsystem: metrics.SubSystem,
 			Name:      KeyFrameworkTotal,
 			Help:      "Gauge of client framework info in Service Center",
 		}, metrics.ToLabelNames(Framework{}))
@@ -126,12 +123,18 @@ func ReportServices(domain, framework, frameworkVersion string, c float64) {
 	instance := metrics.InstanceName()
 	serviceCounter.WithLabelValues(instance, framework, frameworkVersion, domain).Add(c)
 }
-
+func GetTotalService(domain string) int64 {
+	return metrics.GaugeValue(strings.Join([]string{metrics.SubSystem, metrics.KeyServiceTotal}, "_"), prometheus.Labels{"domain": domain})
+}
 func ReportInstances(domain string, c float64) {
 	instance := metrics.InstanceName()
 	instanceCounter.WithLabelValues(instance, domain).Add(c)
 }
-
+func GetTotalInstance(domain string) int64 {
+	mn := strings.Join([]string{metrics.SubSystem, metrics.KeyInstanceTotal}, "_")
+	usage := metrics.GaugeValue(mn, prometheus.Labels{"domain": domain})
+	return usage
+}
 func ReportSchemas(domain string, c float64) {
 	instance := metrics.InstanceName()
 	schemaCounter.WithLabelValues(instance, domain).Add(c)

--- a/server/plugin/quota/quota.go
+++ b/server/plugin/quota/quota.go
@@ -23,9 +23,8 @@ import (
 	"fmt"
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/pkg/log"
-	"github.com/apache/servicecomb-service-center/pkg/metrics"
 	"github.com/apache/servicecomb-service-center/pkg/util"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/apache/servicecomb-service-center/server/metrics"
 	"strconv"
 
 	"github.com/apache/servicecomb-service-center/server/config"
@@ -49,10 +48,6 @@ const (
 	TypeTag
 	TypeService
 	TypeInstance
-)
-const (
-	TotalService  = "db_service_total"
-	TotalInstance = "db_instance_total"
 )
 
 var (
@@ -141,9 +136,10 @@ func GetResourceUsage(ctx context.Context, res *ApplyQuotaResource) (int64, erro
 	serviceID := res.ServiceID
 	switch res.QuotaType {
 	case TypeService:
-		return metrics.GaugeValue(TotalService, prometheus.Labels{"domain": util.ParseDomain(ctx)}), nil
+		return metrics.GetTotalService(util.ParseDomain(ctx)), nil
 	case TypeInstance:
-		return metrics.GaugeValue(TotalInstance, prometheus.Labels{"domain": util.ParseDomain(ctx)}), nil
+		usage := metrics.GetTotalInstance(util.ParseDomain(ctx))
+		return usage, nil
 	case TypeRule:
 		{
 			resp, err := datasource.Instance().GetRules(ctx, &pb.GetServiceRulesRequest{


### PR DESCRIPTION
在设计中，defer handler会在一个条件下被Reset，导致自我保护机制中残留需要被重放的实例删除event，实例删除event不被重放，那么就会涉及到很多数据一致性问题，例如当前的实例占用数量，导致配额数据不重启就永远不刷新