### PR TITLE
increase token signing performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ docs/_templates
 /cmd/scctl/scctl
 /cmd/scserver/scserver
 /cmd/syncer/syncer
+main

--- a/pkg/privacy/password.go
+++ b/pkg/privacy/password.go
@@ -26,10 +26,7 @@ import (
 )
 
 const (
-	algBcrypt  = "$2a$"
-	algBcrypt2 = "$2b$"
-	algBcrypt3 = "$2x$"
-	algBcrypt4 = "$2y$"
+	algBcrypt = "$2a$"
 )
 
 //HashPassword
@@ -49,7 +46,7 @@ func ScryptPassword(pwd string) (string, error) {
 	return string(hash), nil
 }
 func SamePassword(hashedPwd, pwd string) bool {
-	if isEncodedByBcrypt(hashedPwd) {
+	if strings.HasPrefix(hashedPwd, algBcrypt) {
 		err := bcrypt.CompareHashAndPassword([]byte(hashedPwd), []byte(pwd))
 		if err == bcrypt.ErrMismatchedHashAndPassword {
 			log.Warn("incorrect password attempts")
@@ -62,9 +59,4 @@ func SamePassword(hashedPwd, pwd string) bool {
 	}
 	return err == nil
 
-}
-func isEncodedByBcrypt(hashedPwd string) bool {
-	return strings.HasPrefix(hashedPwd, algBcrypt) ||
-		strings.HasPrefix(hashedPwd, algBcrypt2) ||
-		strings.HasPrefix(hashedPwd, algBcrypt3) || strings.HasPrefix(hashedPwd, algBcrypt4)
 }

--- a/pkg/privacy/password_test.go
+++ b/pkg/privacy/password_test.go
@@ -37,3 +37,37 @@ func TestHashPassword(t *testing.T) {
 	sameMac := privacy.SamePassword(mac, "test")
 	assert.True(t, sameMac)
 }
+func BenchmarkBcrypt(b *testing.B) {
+	h, _ := privacy.HashPassword("test")
+	for i := 0; i < b.N; i++ {
+		same := privacy.SamePassword(h, "test")
+		if !same {
+			panic("")
+		}
+
+	}
+	b.ReportAllocs()
+}
+func BenchmarkScrypt(b *testing.B) {
+	h, _ := privacy.ScryptPassword("test")
+	for i := 0; i < b.N; i++ {
+		same := privacy.SamePassword(h, "test")
+		if !same {
+			panic("")
+		}
+
+	}
+	b.ReportAllocs()
+}
+func BenchmarkScryptP(b *testing.B) {
+	h, _ := privacy.ScryptPassword("test")
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			same := privacy.SamePassword(h, "test")
+			if !same {
+				panic("")
+			}
+		}
+	})
+	b.ReportAllocs()
+}

--- a/server/service/rbac/authr_plugin.go
+++ b/server/service/rbac/authr_plugin.go
@@ -45,14 +45,6 @@ func (a *EmbeddedAuthenticator) Login(ctx context.Context, user string, password
 	for _, o := range opts {
 		o(opt)
 	}
-	exist, err := dao.AccountExist(ctx, user)
-	if err != nil {
-		log.Error("check account err", err)
-		return "", err
-	}
-	if !exist {
-		return "", ErrUnauthorized
-	}
 	account, err := dao.GetAccount(ctx, user)
 	if err != nil {
 		log.Error("get account err", err)

--- a/version/version.go
+++ b/version/version.go
@@ -19,8 +19,9 @@ package version
 
 import (
 	"fmt"
-	"github.com/apache/servicecomb-service-center/pkg/log"
 	"runtime"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
 )
 
 var (


### PR DESCRIPTION
go版的bcrypt算法prefix都是2a 不会有别的