### PR TITLE
There is no need to send heartbeat when the instance is registered successfully

### DIFF
--- a/datasource/mongo/ms.go
+++ b/datasource/mongo/ms.go
@@ -1956,17 +1956,6 @@ func registryInstance(ctx context.Context, request *discovery.RegisterInstanceRe
 
 	log.Info(fmt.Sprintf("register instance %s, instanceID %s, operator %s",
 		instanceFlag, insertRes.InsertedID, remoteIP))
-	heartbeatRequest := discovery.HeartbeatRequest{
-		ServiceId:  instance.ServiceId,
-		InstanceId: instance.InstanceId,
-	}
-	aliveErr := KeepAliveLease(ctx, &heartbeatRequest)
-	if aliveErr != nil {
-		log.Error(fmt.Sprintf("failed to send heartbeat after registering instance, instance %s operator %s", instanceFlag, remoteIP), err)
-		return &discovery.RegisterInstanceResponse{
-			Response: discovery.CreateResponseWithSCErr(aliveErr),
-		}, err
-	}
 	return &discovery.RegisterInstanceResponse{
 		Response:   discovery.CreateResponse(discovery.ResponseSuccess, "Register service instance successfully."),
 		InstanceId: instanceID,


### PR DESCRIPTION
【issue】: #926
【特性/模块名称】：性能优化
【修改内容】：
创建实例成功后，没有必要去再去掉心跳，这样会降低注册实例接口调用的性能，若注册成功后未发心跳，删除工作由mongo来删除（目前300s） ，之前pr https://github.com/apache/servicecomb-service-center/pull/872

1.剔除创建实例成功后去发送心跳

【自测情况】：ut全部通过