### PR TITLE
SCB-2094 Fix: Nonstandard naming Heartbeatcheck

### DIFF
--- a/datasource/mongo/heartbeat/cache/heartbeatcache.go
+++ b/datasource/mongo/heartbeat/cache/heartbeatcache.go
@@ -40,17 +40,17 @@ const (
 var ErrHeartbeatConversionFailed = errors.New("instanceHeartbeatInfo type conversion failed. ")
 
 func init() {
-	heartbeat.Install("cache", NewHeartBeatCheck)
+	heartbeat.Install("cache", NewHeartBeatCache)
 }
 
-type HeartBeatCheck struct {
+type HeartBeatCache struct {
 }
 
-func NewHeartBeatCheck(opts heartbeat.Options) (heartbeat.HealthCheck, error) {
-	return &HeartBeatCheck{}, nil
+func NewHeartBeatCache(opts heartbeat.Options) (heartbeat.HealthCheck, error) {
+	return &HeartBeatCache{}, nil
 }
 
-func (h *HeartBeatCheck) Heartbeat(ctx context.Context, request *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error) {
+func (h *HeartBeatCache) Heartbeat(ctx context.Context, request *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error) {
 	if ins, ok := instanceHeartbeatStore.Get(request.InstanceId); ok {
 		return inCacheStrategy(ctx, request, ins)
 	}

--- a/datasource/mongo/heartbeat/cache/heartbeatcache_test.go
+++ b/datasource/mongo/heartbeat/cache/heartbeatcache_test.go
@@ -33,7 +33,7 @@ import (
 
 func TestHeartBeatCheck(t *testing.T) {
 	t.Run("heartbeat check: instance does not exist,it should be failed", func(t *testing.T) {
-		heartBeatCheck := &HeartBeatCheck{}
+		heartBeatCheck := &HeartBeatCache{}
 		resp, err := heartBeatCheck.Heartbeat(context.Background(), &pb.HeartbeatRequest{
 			ServiceId:  "serviceId1",
 			InstanceId: "not-exist-ins",
@@ -45,7 +45,7 @@ func TestHeartBeatCheck(t *testing.T) {
 	t.Run("heartbeat check: data exists in the cache,but not in db,it should be failed", func(t *testing.T) {
 		err := addHeartbeatTask("not-exist-svc", "not-exist-ins", 30)
 		assert.Nil(t, err)
-		heartBeatCheck := &HeartBeatCheck{}
+		heartBeatCheck := &HeartBeatCache{}
 		resp, err := heartBeatCheck.Heartbeat(context.Background(), &pb.HeartbeatRequest{
 			ServiceId:  "serviceId1",
 			InstanceId: "not-exist-ins",
@@ -55,7 +55,7 @@ func TestHeartBeatCheck(t *testing.T) {
 	})
 
 	t.Run("heartbeat check: data exists in the cache and db,it can be update successfully", func(t *testing.T) {
-		heartBeatCheck := &HeartBeatCheck{}
+		heartBeatCheck := &HeartBeatCache{}
 		instanceDB := model.Instance{
 			RefreshTime: time.Now(),
 			Instance: &pb.MicroServiceInstance{


### PR DESCRIPTION
【issue】: #942
【特性/模块名称】：cache插件命名不规范，可读性不行
【修改内容】：
1. cache插件的命名不好理解，修改为HeartBeatCache

【自测情况】：ut全部通过

【学习】

go init是根据包导入位置来定的，所以心跳插件加载时，map是不需要加锁的。感谢华哥

https://golang.org/ref/spec#Package_initialization

