### PR TITLE
SCB-2094 BugFix: join the heartbeat cache

### DIFF
--- a/datasource/mongo/heartbeat/cache/heartbeat.go
+++ b/datasource/mongo/heartbeat/cache/heartbeat.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
@@ -44,59 +45,61 @@ const (
 	ctxTimeout              = 5 * time.Second
 )
 
-// Store cache structure
-type instanceHeartbeatInfo struct {
-	serviceID   string
-	instanceID  string
-	ttl         int32
-	lastRefresh time.Time
-}
+var ErrHeartbeatTimeout = errors.New("heartbeat task waiting for processing timeout. ")
 
 var (
-	cacheChan              chan *instanceHeartbeatInfo
-	instanceHeartbeatStore = cache.New(0, instanceCheckerInternal)
-	workerNum              = runtime.NumCPU()
-	heartbeatTaskTimeout   = config.GetInt("registry.mongo.heartbeat.timeout", defaultTimeout)
-	ErrHeartbeatTimeout    = errors.New("heartbeat task waiting for processing timeout. ")
+	once sync.Once
+	cfg  cacheConfig
 )
 
-func init() {
-	capacity := config.GetInt("registry.mongo.heartbeat.cacheCapacity", defaultCacheCapacity)
-	cacheChan = make(chan *instanceHeartbeatInfo, capacity)
-	num := config.GetInt("registry.mongo.heartbeat.workerNum", defaultWorkNum)
-	if num != 0 {
-		workerNum = num
-	}
-	instanceHeartbeatStore.OnEvicted(func(k string, v interface{}) {
-		instanceInfo, ok := v.(*instanceHeartbeatInfo)
-		if ok && instanceInfo != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
-			defer cancel()
-			err := cleanInstance(ctx, instanceInfo.serviceID, instanceInfo.instanceID)
-			if err != nil {
-				log.Error("failed to cleanInstance in mongodb.", err)
-			}
-		}
-	})
+type cacheConfig struct {
+	cacheChan              chan *instanceHeartbeatInfo
+	instanceHeartbeatStore *cache.Cache
+	workerNum              int
+	heartbeatTaskTimeout   int
+}
 
-	for i := 1; i <= workerNum; i++ {
-		gopool.Go(func(ctx context.Context) {
-			for {
-				select {
-				case <-ctx.Done():
-					log.Warn("heartbeat work protocol exit.")
-					return
-				case heartbeatInfo, ok := <-cacheChan:
-					if ok {
-						instanceHeartbeatStore.Set(heartbeatInfo.instanceID, heartbeatInfo, time.Duration(heartbeatInfo.ttl)*time.Second)
-					}
+func configuration() *cacheConfig {
+	once.Do(func() {
+		cfg.workerNum = runtime.NumCPU()
+		num := config.GetInt("registry.mongo.heartbeat.workerNum", defaultWorkNum)
+		if num != 0 {
+			cfg.workerNum = num
+		}
+		cfg.heartbeatTaskTimeout = config.GetInt("registry.mongo.heartbeat.timeout", defaultTimeout)
+		cfg.cacheChan = make(chan *instanceHeartbeatInfo, config.GetInt("registry.mongo.heartbeat.cacheCapacity", defaultCacheCapacity))
+		cfg.instanceHeartbeatStore = cache.New(0, instanceCheckerInternal)
+		cfg.instanceHeartbeatStore.OnEvicted(func(k string, v interface{}) {
+			instanceInfo, ok := v.(*instanceHeartbeatInfo)
+			if ok && instanceInfo != nil {
+				ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
+				defer cancel()
+				err := cleanInstance(ctx, instanceInfo.serviceID, instanceInfo.instanceID)
+				if err != nil {
+					log.Error("failed to cleanInstance in mongodb.", err)
 				}
 			}
 		})
-	}
+		for i := 1; i <= cfg.workerNum; i++ {
+			gopool.Go(func(ctx context.Context) {
+				for {
+					select {
+					case <-ctx.Done():
+						log.Warn("heartbeat work protocol exit.")
+						return
+					case heartbeatInfo, ok := <-cfg.cacheChan:
+						if ok {
+							cfg.instanceHeartbeatStore.Set(heartbeatInfo.instanceID, heartbeatInfo, time.Duration(heartbeatInfo.ttl)*time.Second)
+						}
+					}
+				}
+			})
+		}
+	})
+	return &cfg
 }
 
-func addHeartbeatTask(serviceID string, instanceID string, ttl int32) error {
+func (c *cacheConfig) AddHeartbeatTask(serviceID string, instanceID string, ttl int32) error {
 	// Unassigned setting default value is 30s
 	if ttl <= 0 {
 		ttl = defaultTTL
@@ -108,16 +111,16 @@ func addHeartbeatTask(serviceID string, instanceID string, ttl int32) error {
 		lastRefresh: time.Now(),
 	}
 	select {
-	case cacheChan <- newInstance:
+	case c.cacheChan <- newInstance:
 		return nil
-	case <-time.After(time.Duration(heartbeatTaskTimeout) * time.Second):
+	case <-time.After(time.Duration(c.heartbeatTaskTimeout) * time.Second):
 		log.Warn("the heartbeat's channel is full. ")
 		return ErrHeartbeatTimeout
 	}
 }
 
-func RemoveCacheInstance(instanceID string) {
-	instanceHeartbeatStore.Delete(instanceID)
+func (c *cacheConfig) RemoveCacheInstance(instanceID string) {
+	c.instanceHeartbeatStore.Delete(instanceID)
 }
 
 func cleanInstance(ctx context.Context, serviceID string, instanceID string) error {

--- a/datasource/mongo/heartbeat/cache/heartbeat_test.go
+++ b/datasource/mongo/heartbeat/cache/heartbeat_test.go
@@ -42,6 +42,8 @@ func init() {
 	client.NewMongoClient(config)
 }
 
+var c = configuration()
+
 func TestAddCacheInstance(t *testing.T) {
 	t.Run("add cache instance: set the ttl to 2 seconds", func(t *testing.T) {
 		instance1 := model.Instance{
@@ -55,11 +57,11 @@ func TestAddCacheInstance(t *testing.T) {
 				},
 			},
 		}
-		err := addHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
+		err := c.AddHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
 		assert.Equal(t, nil, err)
 		_, err = client.GetMongoClient().Insert(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
-		info, ok := instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		info, ok := c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, true, ok)
 		if ok {
 			heartBeatInfo := info.(*instanceHeartbeatInfo)
@@ -67,7 +69,7 @@ func TestAddCacheInstance(t *testing.T) {
 			assert.Equal(t, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1), heartBeatInfo.ttl)
 		}
 		time.Sleep(2 * time.Second)
-		_, ok = instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		_, ok = c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, false, ok)
 		_, err = client.GetMongoClient().Delete(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
@@ -85,11 +87,11 @@ func TestAddCacheInstance(t *testing.T) {
 				},
 			},
 		}
-		err := addHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
+		err := c.AddHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
 		assert.Equal(t, nil, err)
 		_, err = client.GetMongoClient().Insert(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
-		info, ok := instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		info, ok := c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, true, ok)
 		if ok {
 			heartBeatInfo := info.(*instanceHeartbeatInfo)
@@ -97,7 +99,7 @@ func TestAddCacheInstance(t *testing.T) {
 			assert.Equal(t, int32(defaultTTL), heartBeatInfo.ttl)
 		}
 		time.Sleep(defaultTTL * time.Second)
-		_, ok = instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		_, ok = c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, false, ok)
 		_, err = client.GetMongoClient().Delete(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
@@ -117,11 +119,11 @@ func TestRemoveCacheInstance(t *testing.T) {
 				},
 			},
 		}
-		err := addHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
+		err := c.AddHeartbeatTask(instance1.Instance.ServiceId, instance1.Instance.InstanceId, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1))
 		assert.Equal(t, nil, err)
 		_, err = client.GetMongoClient().Insert(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)
-		info, ok := instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		info, ok := c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, true, ok)
 		if ok {
 			heartBeatInfo := info.(*instanceHeartbeatInfo)
@@ -129,8 +131,8 @@ func TestRemoveCacheInstance(t *testing.T) {
 			assert.Equal(t, instance1.Instance.HealthCheck.Interval*(instance1.Instance.HealthCheck.Times+1), heartBeatInfo.ttl)
 		}
 		time.Sleep(4 * time.Second)
-		RemoveCacheInstance(instance1.Instance.InstanceId)
-		_, ok = instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
+		c.RemoveCacheInstance(instance1.Instance.InstanceId)
+		_, ok = c.instanceHeartbeatStore.Get(instance1.Instance.InstanceId)
 		assert.Equal(t, false, ok)
 		_, err = client.GetMongoClient().Delete(context.Background(), model.CollectionInstance, instance1)
 		assert.Equal(t, nil, err)

--- a/datasource/mongo/heartbeat/cache/types.go
+++ b/datasource/mongo/heartbeat/cache/types.go
@@ -3,29 +3,26 @@
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
+ * (the "License"); you may not use this file except request compliance with
  * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to request writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
-package heartbeat
+package heartbeatcache
 
-import (
-	"context"
+import "time"
 
-	pb "github.com/go-chassis/cari/discovery"
-)
-
-type HealthCheck interface {
-	// processing heartbeat request
-	Heartbeat(ctx context.Context, request *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error)
-	// processing heartbeat check of instance after registration
-	CheckInstance(ctx context.Context, instance *pb.MicroServiceInstance) error
+// Store cache structure
+type instanceHeartbeatInfo struct {
+	serviceID   string
+	instanceID  string
+	ttl         int32
+	lastRefresh time.Time
 }

--- a/datasource/mongo/heartbeat/checker/heartbeatchecker.go
+++ b/datasource/mongo/heartbeat/checker/heartbeatchecker.go
@@ -54,3 +54,8 @@ func (h *HeartBeatChecker) Heartbeat(ctx context.Context, request *pb.HeartbeatR
 			"Update service instance heartbeat successfully."),
 	}, nil
 }
+
+func (h *HeartBeatChecker) CheckInstance(ctx context.Context, instance *pb.MicroServiceInstance) error {
+	// do nothing
+	return nil
+}


### PR DESCRIPTION
【issue】: #944
【特性/模块名称】：实例及时下线
【修改内容】：

新建接口检查任务，用于创建实例成功后调用，即当db为mongo心跳插件选用cache时，注册实例成功后，加入缓存，用于检查——实现功能，注册完实例后也能及时下线

【自测情况】：ut全部通过