### PR TITLE
role binding check

### DIFF
--- a/datasource/account.go
+++ b/datasource/account.go
@@ -31,6 +31,7 @@ var (
 	ErrDeleteAccountFailed = errors.New("failed to delete account")
 	ErrQueryAccountFailed  = errors.New("failed to query account")
 	ErrAccountNotExist     = errors.New("account not exist")
+	ErrRoleBindingExist    = errors.New("role is bind to account")
 )
 
 // AccountManager contains the RBAC CRUD

--- a/datasource/account_test.go
+++ b/datasource/account_test.go
@@ -83,9 +83,9 @@ func TestAccount(t *testing.T) {
 		a2.Password = "new-password"
 		err = datasource.Instance().UpdateAccount(context.Background(), a2.Name, &a2)
 		assert.NoError(t, err)
-		_, n, err := datasource.Instance().ListAccount(context.Background())
+		accounts, _, err := datasource.Instance().ListAccount(context.Background())
 		assert.NoError(t, err)
-		assert.Equal(t, int64(2), n)
+		assert.GreaterOrEqual(t, len(accounts), 2)
 		_, err = datasource.Instance().DeleteAccount(context.Background(), []string{a1.Name})
 		assert.NoError(t, err)
 		_, err = datasource.Instance().DeleteAccount(context.Background(), []string{a2.Name})

--- a/datasource/etcd/path/key_generator.go
+++ b/datasource/etcd/path/key_generator.go
@@ -76,7 +76,20 @@ func GenerateRBACRoleKey(name string) string {
 		name,
 	}, SPLIT)
 }
-
+func GenRoleAccountIdxKey(role, account string) string {
+	return util.StringJoin([]string{
+		GetRootKey(),
+		"idx-role-account",
+		role, account,
+	}, SPLIT)
+}
+func GenRoleAccountPrefixIdxKey(role string) string {
+	return util.StringJoin([]string{
+		GetRootKey(),
+		"idx-role-account",
+		role,
+	}, SPLIT)
+}
 func GenerateETCDProjectKey(domain, project string) string {
 	return util.StringJoin([]string{
 		GetProjectRootKey(domain),

--- a/datasource/mongo/role.go
+++ b/datasource/mongo/role.go
@@ -19,8 +19,8 @@ package mongo
 
 import (
 	"context"
-
 	"github.com/go-chassis/cari/rbac"
+	"go.mongodb.org/mongo-driver/bson"
 
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
@@ -102,8 +102,12 @@ func (ds *DataSource) ListRole(ctx context.Context) ([]*rbac.Role, int64, error)
 }
 
 func (ds *DataSource) DeleteRole(ctx context.Context, name string) (bool, error) {
+	n, err := client.Count(ctx, model.CollectionAccount, bson.M{"roles": bson.M{"$in": []string{name}}})
+	if n > 0 {
+		return false, datasource.ErrRoleBindingExist
+	}
 	filter := mutil.NewFilter(mutil.RoleName(name))
-	result, err := client.GetMongoClient().Delete(ctx, model.CollectionRole, filter)
+	result, err := client.DeleteDoc(ctx, model.CollectionRole, filter)
 	if err != nil {
 		return false, err
 	}

--- a/examples/etcd_data_struct.yaml
+++ b/examples/etcd_data_struct.yaml
@@ -130,7 +130,9 @@
     "currentPassword": "password",
     "status": "normal"
   }
-
+# record role binding to account
+/cse-sr/idx-role-account/{role}/{account}:
+  {no value}
 # domain
 # /cse-sr/domains/{domain}
 /cse-sr/domains/default:

--- a/server/resource/v4/role_resource.go
+++ b/server/resource/v4/role_resource.go
@@ -19,6 +19,8 @@ package v4
 
 import (
 	"encoding/json"
+	"errors"
+	"github.com/apache/servicecomb-service-center/datasource"
 	"io/ioutil"
 	"net/http"
 
@@ -138,6 +140,10 @@ func (rr *RoleResource) DeleteRole(w http.ResponseWriter, req *http.Request) {
 	n := req.URL.Query().Get(":roleName")
 
 	status, err := dao.DeleteRole(req.Context(), n)
+	if errors.Is(err, datasource.ErrRoleBindingExist) {
+		rest.WriteError(w, discovery.ErrInvalidParams, errorsEx.MsgJSON)
+		return
+	}
 	if err != nil {
 		log.Error(errorsEx.MsgJSON, err)
 		rest.WriteError(w, discovery.ErrInternal, errorsEx.MsgJSON)


### PR DESCRIPTION
方案：
etcd
- 使用etcd的事务进行账号的增删，增的时候创建角色到账号的映射key path（无value），删的时候也删除映射
- 角色删除时ls 映射的key path，看看是不是存在映射，不存在才能删除

mongo
- 删除角色时，按条件查询下是不是包含在账号内的角色字段内