### PR TITLE
fixbugs: mongo connection pool is full (#1052)

### DIFF
--- a/datasource/mongo/client/mongo.go
+++ b/datasource/mongo/client/mongo.go
@@ -172,6 +172,7 @@ func (mc *MongoClient) newClient(ctx context.Context) (err error) {
 		uri = mc.dbconfig.URI
 	}
 	clientOptions := []*options.ClientOptions{options.Client().ApplyURI(uri)}
+	clientOptions = append(clientOptions, options.Client().SetMaxPoolSize(uint64(mc.dbconfig.PoolSize)))
 	if mc.dbconfig.SSLEnabled {
 		if mc.dbconfig.RootCA == "" {
 			err = ErrRootCAMissing

--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -121,6 +121,7 @@ registry:
       verifyPeer: false
       certFile: /opt/ssl/client.crt
       keyFile: /opt/ssl/client.key
+      poolSize: 1000
   fastRegistration:
     # this config is only support in mongo case now
     # if fastRegister.queueSize is > 0, enable to fast register instance, else register instance in normal case


### PR DESCRIPTION
【issue】: #1052

【特性/模块名称】：mongo db 连接

【修改内容】：
新增配置项registry.mongo.cluster.poolSize，把该参数设置为可以配置的，默认设置为1000
创建mongoclient的时候传入参数，扩大go driver与mongo的连接数量

【自测情况】：
测试通过，通过配置poolSize可以提高go driver 与mongo的连接数量，高并发场景酌情配置