### PR TITLE
bugfix: GetServicesInfo function return wrong statistics

### DIFF
--- a/datasource/mongo/ms.go
+++ b/datasource/mongo/ms.go
@@ -531,7 +531,7 @@ func (ds *MetadataManager) GetServicesInfo(ctx context.Context, request *discove
 	return &discovery.GetServicesInfoResponse{
 		Response:          discovery.CreateResponse(discovery.ResponseSuccess, "Get services info successfully."),
 		AllServicesDetail: allServiceDetails,
-		Statistics:        nil,
+		Statistics:        st,
 	}, nil
 }
 
@@ -545,7 +545,7 @@ func (ds *MetadataManager) filterServices(ctx context.Context, request *discover
 		opts = append(opts, mutil.ServiceAppID(request.AppId))
 	}
 	if len(request.ServiceName) > 0 {
-		opts = append(opts, mutil.ServiceAppID(request.ServiceName))
+		opts = append(opts, mutil.ServiceServiceName(request.ServiceName))
 	}
 	return mutil.NewBasicFilter(ctx, opts...)
 }


### PR DESCRIPTION
【issue】: #1058
【特性/模块名称】：GetServicesInfo查询错误
【修改内容】：

GetServicesInfo函数
1. 最终返回的 statistics 为nil
2. filter过滤servicename填写错误

【自测情况】：ut全部通过
