### PR TITLE
change service col unique index

### DIFF
--- a/datasource/mongo/mongo.go
+++ b/datasource/mongo/mongo.go
@@ -165,6 +165,8 @@ func EnsureService() {
 	wrapCreateCollectionError(err)
 
 	serviceIDIndex := mutil.BuildIndexDoc(
+		model.ColumnDomain,
+		model.ColumnProject,
 		mutil.ConnectWithDot([]string{model.ColumnService, model.ColumnServiceID}))
 	serviceIDIndex.Options = options.Index().SetUnique(true)
 


### PR DESCRIPTION
【issue】: #1072 

【特性/模块名称】：mongo索引修改

【修改内容】：
1. 使用tenant+服务id为唯一索引，避免两个租户用户指定同服务id冲突的问题

【自测情况】：
测试通过