### PR TITLE
Get service/instance from cache (#1066)

### DIFF
--- a/datasource/cache/ms_cache.go
+++ b/datasource/cache/ms_cache.go
@@ -21,19 +21,15 @@ import (
 	"context"
 	"strings"
 
-	"github.com/go-chassis/cari/discovery"
-
+	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
 	"github.com/apache/servicecomb-service-center/pkg/util"
-)
-
-const (
-	Provider = "p"
+	"github.com/go-chassis/cari/discovery"
 )
 
 func GetProviderServiceOfDeps(provider *discovery.MicroService) (*discovery.MicroServiceDependency, bool) {
-	res := sd.Store().Dep().Cache().GetValue(genDepServiceKey(Provider, provider))
+	res := sd.Store().Dep().Cache().GetValue(genDepServiceKey(datasource.Provider, provider))
 	deps, ok := transCacheToDep(res)
 	if !ok {
 		return nil, false
@@ -60,36 +56,25 @@ func genDepServiceKey(ruleType string, service *discovery.MicroService) string {
 	return strings.Join([]string{ruleType, service.AppId, service.ServiceName, service.Version}, "/")
 }
 
-func GetMicroServiceInstancesByID(serviceID string) ([]*discovery.MicroServiceInstance, bool) {
-	cacheInstances := sd.Store().Instance().Cache().GetValue(serviceID)
-	insts, ok := transCacheToInsts(cacheInstances)
+func GetMicroServiceInstancesByID(ctx context.Context, serviceID string) ([]*discovery.MicroServiceInstance, bool) {
+	index := genServiceIDIndex(ctx, serviceID)
+	cacheInstances := sd.Store().Instance().Cache().GetValue(index)
+	insts, ok := transCacheToMicroInsts(cacheInstances)
 	if !ok {
 		return nil, false
 	}
 	return insts, true
 }
 
-func transCacheToInsts(cache []interface{}) ([]*discovery.MicroServiceInstance, bool) {
-	res := make([]*discovery.MicroServiceInstance, 0, len(cache))
-	for _, iter := range cache {
-		inst, ok := iter.(model.Instance)
-		if !ok {
-			return nil, false
-		}
-		res = append(res, inst.Instance)
-	}
-	if len(res) == 0 {
-		return nil, false
-	}
-	return res, true
-}
-
 func GetServiceByID(ctx context.Context, serviceID string) (*model.Service, bool) {
 	if util.NoCache(ctx) {
 		return nil, false
 	}
-	cacheIndex := strings.Join([]string{util.ParseDomain(ctx), util.ParseProject(ctx), serviceID}, "/")
-	cacheRes := sd.Store().Service().Cache().GetValue(cacheIndex)
+	index := genServiceIDIndex(ctx, serviceID)
+	cacheRes := sd.Store().Service().Cache().GetValue(index)
+	if len(cacheRes) == 0 {
+		return nil, false
+	}
 	res, ok := transCacheToService(cacheRes)
 	if !ok {
 		return nil, false
@@ -97,17 +82,67 @@ func GetServiceByID(ctx context.Context, serviceID string) (*model.Service, bool
 	return res[0], true
 }
 
+func GetServiceByName(ctx context.Context, key *discovery.MicroServiceKey) ([]*model.Service, bool) {
+	if util.NoCache(ctx) {
+		return nil, false
+	}
+	cacheIndex := genServiceNameIndex(ctx, key)
+	res := sd.Store().Service().Cache().GetValue(cacheIndex)
+	cacheService, ok := transCacheToService(res)
+	if !ok {
+		return nil, false
+	}
+	return cacheService, true
+}
+
 func GetServiceID(ctx context.Context, key *discovery.MicroServiceKey) (serviceID string, exist bool) {
 	if util.NoCache(ctx) {
 		return
 	}
-	cacheIndex := strings.Join([]string{util.ParseDomain(ctx), util.ParseProject(ctx), key.AppId, key.ServiceName, key.Version}, "/")
+	cacheIndex := genServiceKeyIndex(ctx, key)
 	res := sd.Store().Service().Cache().GetValue(cacheIndex)
 	cacheService, ok := transCacheToService(res)
 	if !ok {
 		return
 	}
 	return cacheService[0].Service.ServiceId, true
+}
+
+func GetServiceByIDAcrossDomain(ctx context.Context, serviceID string) (*model.Service, bool) {
+	index := genServiceIDIndexAcrossDomain(ctx, serviceID)
+	cacheRes := sd.Store().Service().Cache().GetValue(index)
+
+	if len(cacheRes) == 0 {
+		return nil, false
+	}
+
+	res, ok := transCacheToService(cacheRes)
+	if !ok {
+		return nil, false
+	}
+
+	return res[0], true
+}
+
+func GetServicesByDomainProject(domainProject string) (service []*model.Service, exist bool) {
+	services := make([]*model.Service, 0)
+	sd.Store().Service().Cache().GetValue(domainProject)
+	if len(services) == 0 {
+		return services, false
+	}
+	return services, true
+}
+
+func GetMicroServicesByDomainProject(domainProject string) (service []*discovery.MicroService, exist bool) {
+	services, exist := GetServicesByDomainProject(domainProject)
+	if !exist || len(services) == 0 {
+		return nil, false
+	}
+	ms := make([]*discovery.MicroService, len(services))
+	for i, s := range services {
+		ms[i] = s.Service
+	}
+	return ms, true
 }
 
 func transCacheToService(services []interface{}) ([]*model.Service, bool) {
@@ -128,4 +163,87 @@ func transCacheToService(services []interface{}) ([]*model.Service, bool) {
 		return nil, false
 	}
 	return res, true
+}
+
+func genServiceIDIndexAcrossDomain(ctx context.Context, serviceID string) string {
+	return strings.Join([]string{util.ParseTargetDomainProject(ctx), serviceID}, datasource.SPLIT)
+}
+
+func genServiceIDIndex(ctx context.Context, serviceID string) string {
+	return strings.Join([]string{util.ParseDomainProject(ctx), serviceID}, datasource.SPLIT)
+}
+
+func genServiceKeyIndex(ctx context.Context, key *discovery.MicroServiceKey) string {
+	return strings.Join([]string{util.ParseDomain(ctx), util.ParseProject(ctx), key.AppId, key.ServiceName, key.Version}, datasource.SPLIT)
+}
+
+func genServiceNameIndex(ctx context.Context, key *discovery.MicroServiceKey) string {
+	return strings.Join([]string{util.ParseDomain(ctx), util.ParseProject(ctx), key.AppId, key.ServiceName}, datasource.SPLIT)
+}
+
+func CountInstances(ctx context.Context, serviceID string) (int, bool) {
+	index := genServiceIDIndex(ctx, serviceID)
+	cacheInstances := sd.Store().Instance().Cache().GetValue(index)
+	if len(cacheInstances) == 0 {
+		return 0, false
+	}
+	return len(cacheInstances), true
+}
+
+func GetInstance(ctx context.Context, serviceID string, instanceID string) (*model.Instance, bool) {
+	index := generateInstanceIDIndex(util.ParseDomainProject(ctx), serviceID, instanceID)
+	cacheInstance := sd.Store().Instance().Cache().GetValue(index)
+	insts, ok := transCacheToInsts(cacheInstance)
+	if !ok {
+		return nil, false
+	}
+	return insts[0], true
+}
+
+func GetInstances(ctx context.Context) ([]*model.Instance, bool) {
+	index := util.ParseDomainProject(ctx)
+	cacheInstance := sd.Store().Instance().Cache().GetValue(index)
+	insts, ok := transCacheToInsts(cacheInstance)
+	if !ok {
+		return nil, false
+	}
+	return insts, true
+}
+
+func transCacheToMicroInsts(cache []interface{}) ([]*discovery.MicroServiceInstance, bool) {
+	res := make([]*discovery.MicroServiceInstance, 0, len(cache))
+	for _, iter := range cache {
+		inst, ok := iter.(model.Instance)
+		if !ok {
+			return nil, false
+		}
+		res = append(res, inst.Instance)
+	}
+	if len(res) == 0 {
+		return nil, false
+	}
+	return res, true
+}
+
+func transCacheToInsts(cache []interface{}) ([]*model.Instance, bool) {
+	res := make([]*model.Instance, 0, len(cache))
+	for _, iter := range cache {
+		inst, ok := iter.(model.Instance)
+		if !ok {
+			return nil, false
+		}
+		res = append(res, &inst)
+	}
+	if len(res) == 0 {
+		return nil, false
+	}
+	return res, true
+}
+
+func generateInstanceIDIndex(domainProject string, serviceID string, instanceID string) string {
+	return util.StringJoin([]string{
+		domainProject,
+		serviceID,
+		instanceID,
+	}, datasource.SPLIT)
 }

--- a/datasource/common.go
+++ b/datasource/common.go
@@ -30,6 +30,7 @@ const (
 	RegistryProject       = "default"
 	RegistryDomainProject = "default/default"
 	RegistryAppID         = "default"
+	Provider              = "p"
 )
 
 // WrapErrResponse is temp func here to wait finish to refact the discosvc pkg

--- a/datasource/instance_test.go
+++ b/datasource/instance_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestInstance_Create(t *testing.T) {
-	var serviceId string
+	var serviceID string
 
 	t.Run("create service", func(t *testing.T) {
 		respCreateService, err := datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
@@ -48,13 +48,13 @@ func TestInstance_Create(t *testing.T) {
 
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId = respCreateService.ServiceId
+		serviceID = respCreateService.ServiceId
 	})
 
 	t.Run("register instance", func(t *testing.T) {
 		respCreateInst, err := datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId,
+				ServiceId: serviceID,
 				Endpoints: []string{
 					"createInstance_ms:127.0.0.1:8080",
 				},
@@ -69,7 +69,7 @@ func TestInstance_Create(t *testing.T) {
 		respCreateInst, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
 				InstanceId: "customId_ms",
-				ServiceId:  serviceId,
+				ServiceId:  serviceID,
 				Endpoints: []string{
 					"createInstance_ms:127.0.0.1:8080",
 				},
@@ -84,7 +84,7 @@ func TestInstance_Create(t *testing.T) {
 
 	t.Run("update the same instance", func(t *testing.T) {
 		instance := &pb.MicroServiceInstance{
-			ServiceId: serviceId,
+			ServiceId: serviceID,
 			Endpoints: []string{
 				"sameInstance:127.0.0.1:8080",
 			},
@@ -108,9 +108,9 @@ func TestInstance_Create(t *testing.T) {
 
 func TestInstance_HeartBeat(t *testing.T) {
 	var (
-		serviceId   string
-		instanceId1 string
-		instanceId2 string
+		serviceID   string
+		instanceID1 string
+		instanceID2 string
 	)
 
 	t.Run("register service and instance, should pass", func(t *testing.T) {
@@ -126,11 +126,11 @@ func TestInstance_HeartBeat(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId = respCreateService.ServiceId
+		serviceID = respCreateService.ServiceId
 
 		respCreateInstance, err := datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId,
+				ServiceId: serviceID,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"heartbeat:127.0.0.1:8080",
@@ -140,11 +140,11 @@ func TestInstance_HeartBeat(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId1 = respCreateInstance.InstanceId
+		instanceID1 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId,
+				ServiceId: serviceID,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"heartbeat:127.0.0.2:8080",
@@ -154,14 +154,14 @@ func TestInstance_HeartBeat(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId2 = respCreateInstance.InstanceId
+		instanceID2 = respCreateInstance.InstanceId
 	})
 
 	t.Run("update a lease", func(t *testing.T) {
 		log.Info("valid instance")
 		resp, err := datasource.GetMetadataManager().Heartbeat(getContext(), &pb.HeartbeatRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId1,
+			ServiceId:  serviceID,
+			InstanceId: instanceID1,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
@@ -169,14 +169,14 @@ func TestInstance_HeartBeat(t *testing.T) {
 		log.Info("serviceId does not exist")
 		resp, err = datasource.GetMetadataManager().Heartbeat(getContext(), &pb.HeartbeatRequest{
 			ServiceId:  "100000000000",
-			InstanceId: instanceId1,
+			InstanceId: instanceID1,
 		})
 		assert.NoError(t, err)
 		assert.NotEqual(t, pb.ResponseSuccess, resp.Response.GetCode())
 
 		log.Info("instance does not exist")
 		resp, err = datasource.GetMetadataManager().Heartbeat(getContext(), &pb.HeartbeatRequest{
-			ServiceId:  serviceId,
+			ServiceId:  serviceID,
 			InstanceId: "not-exist-ins",
 		})
 		assert.NoError(t, err)
@@ -188,12 +188,12 @@ func TestInstance_HeartBeat(t *testing.T) {
 		resp, err := datasource.GetMetadataManager().HeartbeatSet(getContext(), &pb.HeartbeatSetRequest{
 			Instances: []*pb.HeartbeatSetElement{
 				{
-					ServiceId:  serviceId,
-					InstanceId: instanceId1,
+					ServiceId:  serviceID,
+					InstanceId: instanceID1,
 				},
 				{
-					ServiceId:  serviceId,
-					InstanceId: instanceId2,
+					ServiceId:  serviceID,
+					InstanceId: instanceID2,
 				},
 			},
 		})
@@ -204,8 +204,8 @@ func TestInstance_HeartBeat(t *testing.T) {
 
 func TestInstance_Update(t *testing.T) {
 	var (
-		serviceId  string
-		instanceId string
+		serviceID  string
+		instanceID string
 	)
 
 	t.Run("register service and instance, should pass", func(t *testing.T) {
@@ -221,12 +221,12 @@ func TestInstance_Update(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId = respCreateService.ServiceId
+		serviceID = respCreateService.ServiceId
 
 		log.Info("create instance")
 		respCreateInstance, err := datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId,
+				ServiceId: serviceID,
 				Endpoints: []string{
 					"updateInstance:127.0.0.1:8080",
 				},
@@ -237,14 +237,14 @@ func TestInstance_Update(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId = respCreateInstance.InstanceId
+		instanceID = respCreateInstance.InstanceId
 	})
 
 	t.Run("update instance status", func(t *testing.T) {
 		log.Info("update instance status to DOWN")
 		respUpdateStatus, err := datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId,
+			ServiceId:  serviceID,
+			InstanceId: instanceID,
 			Status:     pb.MSI_DOWN,
 		})
 		assert.NoError(t, err)
@@ -252,8 +252,8 @@ func TestInstance_Update(t *testing.T) {
 
 		log.Info("update instance status to OUTOFSERVICE")
 		respUpdateStatus, err = datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId,
+			ServiceId:  serviceID,
+			InstanceId: instanceID,
 			Status:     pb.MSI_OUTOFSERVICE,
 		})
 		assert.NoError(t, err)
@@ -261,8 +261,8 @@ func TestInstance_Update(t *testing.T) {
 
 		log.Info("update instance status to STARTING")
 		respUpdateStatus, err = datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId,
+			ServiceId:  serviceID,
+			InstanceId: instanceID,
 			Status:     pb.MSI_STARTING,
 		})
 		assert.NoError(t, err)
@@ -270,8 +270,8 @@ func TestInstance_Update(t *testing.T) {
 
 		log.Info("update instance status to TESTING")
 		respUpdateStatus, err = datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId,
+			ServiceId:  serviceID,
+			InstanceId: instanceID,
 			Status:     pb.MSI_TESTING,
 		})
 		assert.NoError(t, err)
@@ -279,8 +279,8 @@ func TestInstance_Update(t *testing.T) {
 
 		log.Info("update instance status to UP")
 		respUpdateStatus, err = datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
-			InstanceId: instanceId,
+			ServiceId:  serviceID,
+			InstanceId: instanceID,
 			Status:     pb.MSI_UP,
 		})
 		assert.NoError(t, err)
@@ -288,7 +288,7 @@ func TestInstance_Update(t *testing.T) {
 
 		log.Info("update instance status with a not exist instance")
 		respUpdateStatus, err = datasource.GetMetadataManager().UpdateInstanceStatus(getContext(), &pb.UpdateInstanceStatusRequest{
-			ServiceId:  serviceId,
+			ServiceId:  serviceID,
 			InstanceId: "notexistins",
 			Status:     pb.MSI_STARTING,
 		})
@@ -300,8 +300,8 @@ func TestInstance_Update(t *testing.T) {
 		log.Info("update one properties")
 		respUpdateProperties, err := datasource.GetMetadataManager().UpdateInstanceProperties(getContext(),
 			&pb.UpdateInstancePropsRequest{
-				ServiceId:  serviceId,
-				InstanceId: instanceId,
+				ServiceId:  serviceID,
+				InstanceId: instanceID,
 				Properties: map[string]string{
 					"test": "test",
 				},
@@ -318,8 +318,8 @@ func TestInstance_Update(t *testing.T) {
 		}
 		respUpdateProperties, err = datasource.GetMetadataManager().UpdateInstanceProperties(getContext(),
 			&pb.UpdateInstancePropsRequest{
-				ServiceId:  serviceId,
-				InstanceId: instanceId,
+				ServiceId:  serviceID,
+				InstanceId: instanceID,
 				Properties: properties,
 			})
 		assert.NoError(t, err)
@@ -328,7 +328,7 @@ func TestInstance_Update(t *testing.T) {
 		log.Info("update instance that does not exist")
 		respUpdateProperties, err = datasource.GetMetadataManager().UpdateInstanceProperties(getContext(),
 			&pb.UpdateInstancePropsRequest{
-				ServiceId:  serviceId,
+				ServiceId:  serviceID,
 				InstanceId: "not_exist_ins",
 				Properties: map[string]string{
 					"test": "test",
@@ -340,8 +340,8 @@ func TestInstance_Update(t *testing.T) {
 		log.Info("remove properties")
 		respUpdateProperties, err = datasource.GetMetadataManager().UpdateInstanceProperties(getContext(),
 			&pb.UpdateInstancePropsRequest{
-				ServiceId:  serviceId,
-				InstanceId: instanceId,
+				ServiceId:  serviceID,
+				InstanceId: instanceID,
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respUpdateProperties.Response.GetCode())
@@ -350,7 +350,7 @@ func TestInstance_Update(t *testing.T) {
 		respUpdateProperties, err = datasource.GetMetadataManager().UpdateInstanceProperties(getContext(),
 			&pb.UpdateInstancePropsRequest{
 				ServiceId:  "not_exist_service",
-				InstanceId: instanceId,
+				InstanceId: instanceID,
 				Properties: map[string]string{
 					"test": "test",
 				},
@@ -362,21 +362,21 @@ func TestInstance_Update(t *testing.T) {
 
 func TestInstance_Query(t *testing.T) {
 	var (
-		serviceId1  string
-		serviceId2  string
-		serviceId3  string
-		serviceId4  string
-		serviceId5  string
-		serviceId6  string
-		serviceId7  string
-		serviceId8  string
-		serviceId9  string
-		instanceId1 string
-		instanceId2 string
-		instanceId4 string
-		instanceId5 string
-		instanceId8 string
-		instanceId9 string
+		serviceID1  string
+		serviceID2  string
+		serviceID3  string
+		serviceID4  string
+		serviceID5  string
+		serviceID6  string
+		serviceID7  string
+		serviceID8  string
+		serviceID9  string
+		instanceID1 string
+		instanceID2 string
+		instanceID4 string
+		instanceID5 string
+		instanceID8 string
+		instanceID9 string
 	)
 
 	t.Run("register services and instances for testInstance_query", func(t *testing.T) {
@@ -391,7 +391,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId1 = respCreateService.ServiceId
+		serviceID1 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -404,7 +404,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId2 = respCreateService.ServiceId
+		serviceID2 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -417,7 +417,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId3 = respCreateService.ServiceId
+		serviceID3 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -431,7 +431,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId4 = respCreateService.ServiceId
+		serviceID4 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -448,7 +448,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId5 = respCreateService.ServiceId
+		serviceID5 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(
 			util.SetDomainProject(util.CloneContext(getContext()), "user", "user"),
@@ -463,7 +463,7 @@ func TestInstance_Query(t *testing.T) {
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId6 = respCreateService.ServiceId
+		serviceID6 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -476,7 +476,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId7 = respCreateService.ServiceId
+		serviceID7 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -489,7 +489,7 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId8 = respCreateService.ServiceId
+		serviceID8 = respCreateService.ServiceId
 
 		respCreateService, err = datasource.GetMetadataManager().RegisterService(getContext(), &pb.CreateServiceRequest{
 			Service: &pb.MicroService{
@@ -502,11 +502,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateService.Response.GetCode())
-		serviceId9 = respCreateService.ServiceId
+		serviceID9 = respCreateService.ServiceId
 
 		respCreateInstance, err := datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId1,
+				ServiceId: serviceID1,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.1:8080",
@@ -516,11 +516,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId1 = respCreateInstance.InstanceId
+		instanceID1 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId2,
+				ServiceId: serviceID2,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.2:8080",
@@ -530,11 +530,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId2 = respCreateInstance.InstanceId
+		instanceID2 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId4,
+				ServiceId: serviceID4,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.4:8080",
@@ -544,11 +544,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId4 = respCreateInstance.InstanceId
+		instanceID4 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId5,
+				ServiceId: serviceID5,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.5:8080",
@@ -558,11 +558,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId5 = respCreateInstance.InstanceId
+		instanceID5 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId8,
+				ServiceId: serviceID8,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.8:8080",
@@ -572,11 +572,11 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId8 = respCreateInstance.InstanceId
+		instanceID8 = respCreateInstance.InstanceId
 
 		respCreateInstance, err = datasource.GetMetadataManager().RegisterInstance(getContext(), &pb.RegisterInstanceRequest{
 			Instance: &pb.MicroServiceInstance{
-				ServiceId: serviceId9,
+				ServiceId: serviceID9,
 				HostName:  "UT-HOST-MS",
 				Endpoints: []string{
 					"find:127.0.0.9:8080",
@@ -586,24 +586,24 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respCreateInstance.Response.GetCode())
-		instanceId9 = respCreateInstance.InstanceId
+		instanceID9 = respCreateInstance.InstanceId
 	})
 
 	t.Run("query instance, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId1,
+			ConsumerServiceId: serviceID1,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_service_ms",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
-		assertInstancesContain(t, respFind.Instances, instanceId1)
-		assertInstancesContain(t, respFind.Instances, instanceId2)
+		assertInstancesContain(t, respFind.Instances, instanceID1)
+		assertInstancesContain(t, respFind.Instances, instanceID2)
 	})
 
 	t.Run("query not exist service instance, should failed", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId1,
+			ConsumerServiceId: serviceID1,
 			AppId:             "query_instance_ms",
 			ServiceName:       "not-exist",
 		})
@@ -613,14 +613,14 @@ func TestInstance_Query(t *testing.T) {
 
 	t.Run("query instance when with consumerID or specify env without consumerID, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId4,
+			ConsumerServiceId: serviceID4,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_diff_env_service_ms",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Instances))
-		assertInstancesContain(t, respFind.Instances, instanceId4)
+		assertInstancesContain(t, respFind.Instances, instanceID4)
 
 		respFind, err = datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
 			Environment: pb.ENV_PROD,
@@ -630,13 +630,13 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Instances))
-		assertInstancesContain(t, respFind.Instances, instanceId4)
+		assertInstancesContain(t, respFind.Instances, instanceID4)
 	})
 
 	t.Run("query instance with revision, should ok", func(t *testing.T) {
 		ctx := util.SetContext(getContext(), util.CtxNocache, "")
 		respFind, err := datasource.GetMetadataManager().FindInstances(ctx, &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId8,
+			ConsumerServiceId: serviceID8,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_with_rev_ms",
 		})
@@ -644,23 +644,23 @@ func TestInstance_Query(t *testing.T) {
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		rev, _ := ctx.Value(util.CtxResponseRevision).(string)
 		assert.NotEqual(t, 0, len(rev))
-		assertInstancesContain(t, respFind.Instances, instanceId8)
+		assertInstancesContain(t, respFind.Instances, instanceID8)
 
 		util.WithRequestRev(ctx, "x")
 		respFind, err = datasource.GetMetadataManager().FindInstances(ctx, &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId8,
+			ConsumerServiceId: serviceID8,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_with_rev_ms",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, ctx.Value(util.CtxResponseRevision), rev)
-		assertInstancesContain(t, respFind.Instances, instanceId8)
+		assertInstancesContain(t, respFind.Instances, instanceID8)
 	})
 
 	t.Run("find should return 200 if consumer is diff apps, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId3,
+			ConsumerServiceId: serviceID3,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_service_ms",
 		})
@@ -671,7 +671,7 @@ func TestInstance_Query(t *testing.T) {
 
 	t.Run("find provider instance but specify tag does not exist, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId1,
+			ConsumerServiceId: serviceID1,
 			AppId:             "query_instance_ms",
 			ServiceName:       "query_instance_service_ms",
 			Tags:              []string{"not_exist_tag"},
@@ -690,24 +690,24 @@ func TestInstance_Query(t *testing.T) {
 				util.SetDomainProject(util.CloneContext(getContext()), "user", "user"),
 				"default", "default"),
 			&pb.FindInstancesRequest{
-				ConsumerServiceId: serviceId6,
+				ConsumerServiceId: serviceID6,
 				AppId:             "default",
 				ServiceName:       "query_instance_shared_provider_ms",
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Instances))
-		assertInstancesContain(t, respFind.Instances, instanceId5)
+		assertInstancesContain(t, respFind.Instances, instanceID5)
 
 		respFind, err = datasource.GetMetadataManager().FindInstances(getContext(), &pb.FindInstancesRequest{
-			ConsumerServiceId: serviceId7,
+			ConsumerServiceId: serviceID7,
 			AppId:             "default",
 			ServiceName:       "query_instance_shared_provider_ms",
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Instances))
-		assertInstancesContain(t, respFind.Instances, instanceId5)
+		assertInstancesContain(t, respFind.Instances, instanceID5)
 
 		log.Info("query same domain deps")
 		// todo finish ut after implementing GetConsumerDependencies interface
@@ -717,7 +717,7 @@ func TestInstance_Query(t *testing.T) {
 
 	t.Run("batch query instances, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().BatchFind(getContext(), &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId1,
+			ConsumerServiceId: serviceID1,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -747,8 +747,8 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, int64(0), respFind.Services.Updated[0].Index)
-		assertInstancesContain(t, respFind.Services.Updated[0].Instances, instanceId1)
-		assertInstancesContain(t, respFind.Services.Updated[0].Instances, instanceId2)
+		assertInstancesContain(t, respFind.Services.Updated[0].Instances, instanceID1)
+		assertInstancesContain(t, respFind.Services.Updated[0].Instances, instanceID2)
 		assert.Equal(t, int64(2), respFind.Services.Updated[1].Index)
 		assert.Empty(t, respFind.Services.Updated[1].Instances)
 		assert.Equal(t, 2, len(respFind.Services.Failed[0].Indexes))
@@ -757,7 +757,7 @@ func TestInstance_Query(t *testing.T) {
 
 	t.Run("batch query instances without specify env, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().BatchFind(getContext(), &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId4,
+			ConsumerServiceId: serviceID4,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -770,13 +770,13 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Services.Updated[0].Instances))
-		assert.Equal(t, instanceId4, respFind.Services.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID4, respFind.Services.Updated[0].Instances[0].InstanceId)
 	})
 
 	t.Run("batch query instances with revision, should ok", func(t *testing.T) {
 		ctx := util.SetContext(getContext(), util.CtxNocache, "")
 		respFind, err := datasource.GetMetadataManager().BatchFind(ctx, &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId8,
+			ConsumerServiceId: serviceID8,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -794,14 +794,14 @@ func TestInstance_Query(t *testing.T) {
 			Instances: []*pb.FindInstance{
 				{
 					Instance: &pb.HeartbeatSetElement{
-						ServiceId:  serviceId9,
-						InstanceId: instanceId9,
+						ServiceId:  serviceID9,
+						InstanceId: instanceID9,
 					},
 				},
 				{
 					Instance: &pb.HeartbeatSetElement{
-						ServiceId:  serviceId8,
-						InstanceId: instanceId8,
+						ServiceId:  serviceID8,
+						InstanceId: instanceID8,
 					},
 				},
 			},
@@ -811,18 +811,18 @@ func TestInstance_Query(t *testing.T) {
 		rev := respFind.Services.Updated[0].Rev
 		assert.Equal(t, int64(0), respFind.Services.Updated[0].Index)
 		assert.Equal(t, int64(1), respFind.Services.Updated[1].Index)
-		assert.Equal(t, instanceId8, respFind.Services.Updated[0].Instances[0].InstanceId)
-		assert.Equal(t, instanceId9, respFind.Services.Updated[1].Instances[0].InstanceId)
+		assert.Equal(t, instanceID8, respFind.Services.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID9, respFind.Services.Updated[1].Instances[0].InstanceId)
 		assert.NotEqual(t, 0, len(rev))
 		instanceRev := respFind.Instances.Updated[0].Rev
 		assert.Equal(t, int64(0), respFind.Instances.Updated[0].Index)
 		assert.Equal(t, int64(1), respFind.Instances.Updated[1].Index)
-		assert.Equal(t, instanceId9, respFind.Instances.Updated[0].Instances[0].InstanceId)
-		assert.Equal(t, instanceId8, respFind.Instances.Updated[1].Instances[0].InstanceId)
+		assert.Equal(t, instanceID9, respFind.Instances.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID8, respFind.Instances.Updated[1].Instances[0].InstanceId)
 		assert.NotEqual(t, 0, len(instanceRev))
 
 		respFind, err = datasource.GetMetadataManager().BatchFind(ctx, &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId8,
+			ConsumerServiceId: serviceID8,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -835,8 +835,8 @@ func TestInstance_Query(t *testing.T) {
 			Instances: []*pb.FindInstance{
 				{
 					Instance: &pb.HeartbeatSetElement{
-						ServiceId:  serviceId9,
-						InstanceId: instanceId9,
+						ServiceId:  serviceID9,
+						InstanceId: instanceID9,
 					},
 					Rev: "x",
 				},
@@ -844,13 +844,13 @@ func TestInstance_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
-		assert.Equal(t, instanceId8, respFind.Services.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID8, respFind.Services.Updated[0].Instances[0].InstanceId)
 		assert.Equal(t, respFind.Services.Updated[0].Rev, rev)
-		assert.Equal(t, instanceId9, respFind.Instances.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID9, respFind.Instances.Updated[0].Instances[0].InstanceId)
 		assert.Equal(t, instanceRev, respFind.Instances.Updated[0].Rev)
 
 		respFind, err = datasource.GetMetadataManager().BatchFind(ctx, &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId8,
+			ConsumerServiceId: serviceID8,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -863,8 +863,8 @@ func TestInstance_Query(t *testing.T) {
 			Instances: []*pb.FindInstance{
 				{
 					Instance: &pb.HeartbeatSetElement{
-						ServiceId:  serviceId9,
-						InstanceId: instanceId9,
+						ServiceId:  serviceID9,
+						InstanceId: instanceID9,
 					},
 					Rev: instanceRev,
 				},
@@ -878,7 +878,7 @@ func TestInstance_Query(t *testing.T) {
 
 	t.Run("find should return 200 even if consumer is diff apps, should ok", func(t *testing.T) {
 		respFind, err := datasource.GetMetadataManager().BatchFind(getContext(), &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId3,
+			ConsumerServiceId: serviceID3,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -903,7 +903,7 @@ func TestInstance_Query(t *testing.T) {
 				util.SetDomainProject(util.CloneContext(getContext()), "user", "user"),
 				"default", "default"),
 			&pb.BatchFindInstancesRequest{
-				ConsumerServiceId: serviceId6,
+				ConsumerServiceId: serviceID6,
 				Services: []*pb.FindService{
 					{
 						Service: &pb.MicroServiceKey{
@@ -916,10 +916,10 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Services.Updated[0].Instances))
-		assert.Equal(t, instanceId5, respFind.Services.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID5, respFind.Services.Updated[0].Instances[0].InstanceId)
 
 		respFind, err = datasource.GetMetadataManager().BatchFind(getContext(), &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId7,
+			ConsumerServiceId: serviceID7,
 			Services: []*pb.FindService{
 				{
 					Service: &pb.MicroServiceKey{
@@ -932,18 +932,18 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Services.Updated[0].Instances))
-		assert.Equal(t, instanceId5, respFind.Services.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID5, respFind.Services.Updated[0].Instances[0].InstanceId)
 
 		respFind, err = datasource.GetMetadataManager().BatchFind(util.SetTargetDomainProject(
 			util.SetDomainProject(util.CloneContext(getContext()), "user", "user"),
 			"default", "default"),
 			&pb.BatchFindInstancesRequest{
-				ConsumerServiceId: serviceId6,
+				ConsumerServiceId: serviceID6,
 				Instances: []*pb.FindInstance{
 					{
 						Instance: &pb.HeartbeatSetElement{
-							ServiceId:  serviceId5,
-							InstanceId: instanceId5,
+							ServiceId:  serviceID5,
+							InstanceId: instanceID5,
 						},
 					},
 				},
@@ -953,12 +953,12 @@ func TestInstance_Query(t *testing.T) {
 		assert.Equal(t, pb.ErrServiceNotExists, respFind.Instances.Failed[0].Error.Code)
 
 		respFind, err = datasource.GetMetadataManager().BatchFind(getContext(), &pb.BatchFindInstancesRequest{
-			ConsumerServiceId: serviceId7,
+			ConsumerServiceId: serviceID7,
 			Instances: []*pb.FindInstance{
 				{
 					Instance: &pb.HeartbeatSetElement{
-						ServiceId:  serviceId5,
-						InstanceId: instanceId5,
+						ServiceId:  serviceID5,
+						InstanceId: instanceID5,
 					},
 				},
 			},
@@ -966,7 +966,7 @@ func TestInstance_Query(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, pb.ResponseSuccess, respFind.Response.GetCode())
 		assert.Equal(t, 1, len(respFind.Instances.Updated[0].Instances))
-		assert.Equal(t, instanceId5, respFind.Instances.Updated[0].Instances[0].InstanceId)
+		assert.Equal(t, instanceID5, respFind.Instances.Updated[0].Instances[0].InstanceId)
 
 		core.Service.Environment = pb.ENV_DEV
 	})
@@ -976,20 +976,20 @@ func TestInstance_Query(t *testing.T) {
 		UTFunc := func(consumerId string, code int32) {
 			respFind, err := datasource.GetMetadataManager().GetInstances(getContext(), &pb.GetInstancesRequest{
 				ConsumerServiceId: consumerId,
-				ProviderServiceId: serviceId2,
+				ProviderServiceId: serviceID2,
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, code, respFind.Response.GetCode())
 		}
 
-		UTFunc(serviceId3, pb.ErrServiceNotExists)
+		UTFunc(serviceID3, pb.ErrServiceNotExists)
 
-		UTFunc(serviceId1, pb.ResponseSuccess)
+		UTFunc(serviceID1, pb.ResponseSuccess)
 
 		log.Info("diff env")
 		respFind, err := datasource.GetMetadataManager().GetInstances(getContext(), &pb.GetInstancesRequest{
-			ConsumerServiceId: serviceId4,
-			ProviderServiceId: serviceId2,
+			ConsumerServiceId: serviceID4,
+			ProviderServiceId: serviceID2,
 		})
 		assert.NoError(t, err)
 		assert.NotEqual(t, pb.ResponseSuccess, respFind.Response.GetCode())

--- a/datasource/mongo/client/dao/dep.go
+++ b/datasource/mongo/client/dao/dep.go
@@ -20,20 +20,17 @@ package dao
 import (
 	"context"
 
+	mutil "github.com/apache/servicecomb-service-center/datasource/mongo/util"
+
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
-	mutil "github.com/apache/servicecomb-service-center/datasource/mongo/util"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	"github.com/go-chassis/cari/discovery"
 )
 
-const (
-	Provider = "p"
-)
-
 func GetProviderDeps(ctx context.Context, provider *discovery.MicroService) (*discovery.MicroServiceDependency, error) {
-	return getServiceOfDeps(ctx, Provider, provider)
+	return getServiceOfDeps(ctx, datasource.Provider, provider)
 }
 
 func getServiceOfDeps(ctx context.Context, ruleType string, provider *discovery.MicroService) (*discovery.MicroServiceDependency, error) {

--- a/datasource/mongo/dep_util.go
+++ b/datasource/mongo/dep_util.go
@@ -21,10 +21,9 @@ import (
 	"context"
 	"fmt"
 
-	pb "github.com/go-chassis/cari/discovery"
-
 	"github.com/apache/servicecomb-service-center/datasource/cache"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
+	pb "github.com/go-chassis/cari/discovery"
 )
 
 func GetConsumerIDs(ctx context.Context, provider *pb.MicroService) ([]string, error) {
@@ -42,12 +41,9 @@ func GetConsumerIDs(ctx context.Context, provider *pb.MicroService) ([]string, e
 	}
 	consumerIDs := make([]string, 0, len(serviceDeps.Dependency))
 	for _, serviceKeys := range serviceDeps.Dependency {
-		id, ok := cache.GetServiceID(ctx, serviceKeys)
-		if !ok {
-			id, err = dao.GetServiceID(ctx, serviceKeys)
-			if err != nil {
-				return nil, err
-			}
+		id, err := GetServiceID(ctx, serviceKeys)
+		if err != nil {
+			return nil, err
 		}
 		consumerIDs = append(consumerIDs, id)
 	}

--- a/datasource/mongo/dependency_query.go
+++ b/datasource/mongo/dependency_query.go
@@ -23,17 +23,15 @@ import (
 	"fmt"
 	"strings"
 
-	pb "github.com/go-chassis/cari/discovery"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo/options"
-
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/etcd/path"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
-	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/util"
 	"github.com/apache/servicecomb-service-center/pkg/log"
+	pb "github.com/go-chassis/cari/discovery"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 type DependencyRelation struct {
@@ -86,8 +84,7 @@ func (dr *DependencyRelation) GetDependencyProviders(opts ...DependencyRelationF
 		}
 
 		for _, providerID := range providerIDs {
-			filter := util.NewBasicFilter(dr.ctx, util.ServiceServiceID(providerID))
-			provider, err := dao.GetService(dr.ctx, filter)
+			provider, err := GetServiceByID(dr.ctx, providerID)
 			if err != nil {
 				if errors.Is(err, datasource.ErrNoData) {
 					log.Warn(fmt.Sprintf("provider[%s/%s/%s/%s] does not exist",

--- a/datasource/mongo/event/instance_event_handler.go
+++ b/datasource/mongo/event/instance_event_handler.go
@@ -22,20 +22,18 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-chassis/cari/discovery"
+	simple "github.com/apache/servicecomb-service-center/pkg/time"
 
 	"github.com/apache/servicecomb-service-center/datasource"
-	"github.com/apache/servicecomb-service-center/datasource/cache"
 	"github.com/apache/servicecomb-service-center/datasource/mongo"
-	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/sd"
 	"github.com/apache/servicecomb-service-center/pkg/dump"
 	"github.com/apache/servicecomb-service-center/pkg/log"
-	simple "github.com/apache/servicecomb-service-center/pkg/time"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	"github.com/apache/servicecomb-service-center/server/event"
 	"github.com/apache/servicecomb-service-center/server/syncernotify"
+	"github.com/go-chassis/cari/discovery"
 )
 
 // InstanceEventHandler is the handler to handle events
@@ -58,14 +56,11 @@ func (h InstanceEventHandler) OnEvent(evt sd.MongoEvent) {
 	providerInstanceID := instance.Instance.InstanceId
 	domainProject := instance.Domain + "/" + instance.Project
 	ctx := util.SetDomainProject(context.Background(), instance.Domain, instance.Project)
-	res, ok := cache.GetServiceByID(ctx, providerID)
-	var err error
-	if !ok {
-		res, err = dao.GetServiceByID(ctx, providerID)
-		if err != nil {
-			log.Error(fmt.Sprintf("caught [%s] instance[%s/%s] event, endpoints %v, get provider's file failed from db\n",
-				action, providerID, providerInstanceID, instance.Instance.Endpoints), err)
-		}
+
+	res, err := mongo.GetServiceByID(ctx, providerID)
+	if err != nil {
+		log.Error(fmt.Sprintf("caught [%s] instance[%s/%s] event, endpoints %v, get provider's file failed from db\n",
+			action, providerID, providerInstanceID, instance.Instance.Endpoints), err)
 	}
 	if res == nil {
 		return

--- a/datasource/mongo/instance_util.go
+++ b/datasource/mongo/instance_util.go
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo
+
+import (
+	"context"
+
+	"github.com/apache/servicecomb-service-center/datasource/cache"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
+	mutil "github.com/apache/servicecomb-service-center/datasource/mongo/util"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/go-chassis/cari/discovery"
+)
+
+func ExistInstance(ctx context.Context, serviceID string, instanceID string) (bool, error) {
+	inst, ok := cache.GetInstance(ctx, serviceID, instanceID)
+	if ok && inst != nil {
+		return true, nil
+	}
+
+	return dao.ExistInstance(ctx, serviceID, instanceID)
+}
+
+func GetInstance(ctx context.Context, serviceID string, instanceID string) (*model.Instance, error) {
+	inst, ok := cache.GetInstance(ctx, serviceID, instanceID)
+	if ok && inst != nil {
+		return inst, nil
+	}
+	filter := mutil.NewBasicFilter(ctx, mutil.InstanceServiceID(serviceID), mutil.InstanceInstanceID(instanceID))
+	return dao.GetInstance(ctx, filter)
+}
+
+func GetInstances(ctx context.Context) ([]*model.Instance, error) {
+	insts, ok := cache.GetInstances(ctx)
+	if ok {
+		return insts, nil
+	}
+	filter := mutil.NewBasicFilter(ctx)
+	return dao.GetInstances(ctx, filter)
+
+}
+
+func CountInstance(ctx context.Context, serviceID string) (int64, error) {
+	count, ok := cache.CountInstances(ctx, serviceID)
+	if ok {
+		return int64(count), nil
+	}
+	filter := mutil.NewDomainProjectFilter(util.ParseDomain(ctx), util.ParseProject(ctx), mutil.InstanceServiceID(serviceID))
+	return dao.CountInstance(ctx, filter)
+}
+
+func GetAllInstancesOfOneService(ctx context.Context, serviceID string) ([]*discovery.MicroServiceInstance, error) {
+	inst, ok := cache.GetMicroServiceInstancesByID(ctx, serviceID)
+	if ok && inst != nil {
+		return inst, nil
+	}
+
+	return dao.GetMicroServiceInstancesByID(ctx, serviceID)
+}

--- a/datasource/mongo/microservice_util.go
+++ b/datasource/mongo/microservice_util.go
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo
+
+import (
+	"context"
+
+	"github.com/apache/servicecomb-service-center/datasource/cache"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
+	mutil "github.com/apache/servicecomb-service-center/datasource/mongo/util"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/go-chassis/cari/discovery"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+func GetServiceByID(ctx context.Context, serviceID string) (*model.Service, error) {
+	svc, exist := cache.GetServiceByID(ctx, serviceID)
+	if exist && svc != nil {
+		return svc, nil
+	}
+
+	return dao.GetServiceByID(ctx, serviceID)
+}
+
+func GetServiceByIDAcrossDomain(ctx context.Context, serviceID string) (*model.Service, error) {
+	svc, exist := cache.GetServiceByIDAcrossDomain(ctx, serviceID)
+	if exist && svc != nil {
+		return svc, nil
+	}
+	providerDomain, providerProject := util.ParseTargetDomain(ctx), util.ParseTargetProject(ctx)
+	filter := mutil.NewDomainProjectFilter(providerDomain, providerProject, mutil.ServiceServiceID(serviceID))
+	return dao.GetService(ctx, filter)
+}
+
+func ServiceExistID(ctx context.Context, serviceID string) (bool, error) {
+	svc, exist := cache.GetServiceByID(ctx, serviceID)
+	if exist && svc != nil {
+		return true, nil
+	}
+	filter := mutil.NewBasicFilter(ctx, mutil.ServiceServiceID(serviceID))
+	return client.GetMongoClient().DocExist(ctx, model.CollectionService, filter)
+}
+
+func GetAllServicesByDomainProject(ctx context.Context) ([]*model.Service, error) {
+	services, exist := cache.GetServicesByDomainProject(util.ParseDomainProject(ctx))
+	if exist {
+		return services, nil
+	}
+
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	filter := bson.M{model.ColumnDomain: domain, model.ColumnProject: project}
+	return dao.GetServices(ctx, filter)
+}
+
+func GetAllMicroServicesByDomainProject(ctx context.Context) ([]*discovery.MicroService, error) {
+	services, exist := cache.GetMicroServicesByDomainProject(util.ParseDomainProject(ctx))
+	if exist {
+		return services, nil
+	}
+
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	filter := bson.M{model.ColumnDomain: domain, model.ColumnProject: project}
+	return dao.GetMicroServices(ctx, filter)
+}
+
+func GetServiceID(ctx context.Context, key *discovery.MicroServiceKey) (string, error) {
+	serviceID, exist := cache.GetServiceID(ctx, key)
+	if exist && len(serviceID) != 0 {
+		return serviceID, nil
+	}
+	return dao.GetServiceID(ctx, key)
+}

--- a/datasource/mongo/sd/instance_cache.go
+++ b/datasource/mongo/sd/instance_cache.go
@@ -19,11 +19,12 @@ package sd
 
 import (
 	"reflect"
+	"strings"
 
-	cmap "github.com/orcaman/concurrent-map"
-
+	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
 	"github.com/apache/servicecomb-service-center/datasource/sdcommon"
+	cmap "github.com/orcaman/concurrent-map"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -38,7 +39,7 @@ type instanceStore struct {
 func init() {
 	RegisterCacher(instance, newInstanceStore)
 	InstIndexCols = NewIndexCols()
-	InstIndexCols.AddIndexFunc(InstSericeIDIndex)
+	InstIndexCols.AddIndexFunc(InstServiceIDIndex)
 }
 
 func newInstanceStore() *MongoCacher {
@@ -158,7 +159,7 @@ func (s *instanceStore) isValueNotUpdated(value interface{}, newValue interface{
 	return reflect.DeepEqual(newInst, oldInst)
 }
 
-func InstSericeIDIndex(data interface{}) string {
+func InstServiceIDIndex(data interface{}) string {
 	inst := data.(model.Instance)
-	return inst.Instance.ServiceId
+	return strings.Join([]string{inst.Domain, inst.Project, inst.Instance.ServiceId}, datasource.SPLIT)
 }

--- a/datasource/mongo/sd/instancec_test.go
+++ b/datasource/mongo/sd/instancec_test.go
@@ -66,22 +66,45 @@ func TestInstCacheBasicFunc(t *testing.T) {
 		DocumentID: "id2",
 		Value:      inst2,
 	}
-	t.Run("update&&delete instCache, should pass", func(t *testing.T) {
+	t.Run("add instCache, should pass", func(t *testing.T) {
 		instanceCache.cache.ProcessUpdate(event1)
 		assert.Equal(t, instanceCache.cache.Size(), 1)
 		assert.Nil(t, instanceCache.cache.Get("id_not_exist"))
 		assert.Equal(t, inst1.Instance.InstanceId, instanceCache.cache.Get("id1").(model.Instance).Instance.InstanceId)
-		assert.Len(t, instanceCache.cache.GetValue("svcid"), 1)
+		assert.Len(t, instanceCache.cache.GetValue("default/default/svcid"), 1)
 		instanceCache.cache.ProcessUpdate(event2)
 		assert.Equal(t, instanceCache.cache.Size(), 2)
-		assert.Len(t, instanceCache.cache.GetValue("svcid"), 2)
+		assert.Len(t, instanceCache.cache.GetValue("default/default/svcid"), 2)
+
+	})
+
+	t.Run("update instCache, should pass", func(t *testing.T) {
+		assert.Equal(t, inst1, instanceCache.cache.Get("id1").(model.Instance))
+		instUpdate := model.Instance{
+			Domain:  "default",
+			Project: "default",
+			Instance: &discovery.MicroServiceInstance{
+				InstanceId: "123456789",
+				ServiceId:  "svcid",
+				HostName:   "hostUpdate",
+			},
+		}
+		eventUpdate := MongoEvent{
+			DocumentID: "id1",
+			Value:      instUpdate,
+		}
+		instanceCache.cache.ProcessUpdate(eventUpdate)
+		assert.Equal(t, instUpdate, instanceCache.cache.Get("id1").(model.Instance))
+	})
+
+	t.Run("delete instCache, should pass", func(t *testing.T) {
 		instanceCache.cache.ProcessDelete(event1)
 		assert.Nil(t, instanceCache.cache.Get("id1"))
-		assert.Len(t, instanceCache.cache.GetValue("svcid"), 1)
+		assert.Len(t, instanceCache.cache.GetValue("default/default/svcid"), 1)
 		instanceCache.cache.ProcessDelete(event2)
-		assert.Len(t, instanceCache.cache.GetValue("svcid"), 0)
+		assert.Len(t, instanceCache.cache.GetValue("default/default/svcid"), 0)
 		assert.Nil(t, instanceCache.cache.Get("id2"))
-		assert.Len(t, instanceCache.cache.GetValue("svcid"), 0)
+		assert.Len(t, instanceCache.cache.GetValue("default/default/svcid"), 0)
 	})
 }
 

--- a/datasource/mongo/sd/service_cache.go
+++ b/datasource/mongo/sd/service_cache.go
@@ -23,6 +23,7 @@ import (
 
 	cmap "github.com/orcaman/concurrent-map"
 
+	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/datasource/mongo/client/model"
 	"github.com/apache/servicecomb-service-center/datasource/sdcommon"
 	"go.mongodb.org/mongo-driver/bson"
@@ -42,6 +43,7 @@ func init() {
 	ServiceIndexCols.AddIndexFunc(ServiceIDIndex)
 	ServiceIndexCols.AddIndexFunc(ServiceInfoIndex)
 	ServiceIndexCols.AddIndexFunc(ServiceVersionIndex)
+	ServiceIndexCols.AddIndexFunc(ServiceDomainProjectIndex)
 }
 
 func newServiceStore() *MongoCacher {
@@ -162,15 +164,20 @@ func (s *serviceStore) isValueNotUpdated(value interface{}, newValue interface{}
 
 func ServiceIDIndex(data interface{}) string {
 	svc := data.(model.Service)
-	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.ServiceId}, "/")
+	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.ServiceId}, datasource.SPLIT)
 }
 
 func ServiceInfoIndex(data interface{}) string {
 	svc := data.(model.Service)
-	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.AppId, svc.Service.ServiceName, svc.Service.Version}, "/")
+	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.AppId, svc.Service.ServiceName, svc.Service.Version}, datasource.SPLIT)
 }
 
 func ServiceVersionIndex(data interface{}) string {
 	svc := data.(model.Service)
-	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.AppId, svc.Service.ServiceName}, "/")
+	return strings.Join([]string{svc.Domain, svc.Project, svc.Service.AppId, svc.Service.ServiceName}, datasource.SPLIT)
+}
+
+func ServiceDomainProjectIndex(data interface{}) string {
+	svc := data.(model.Service)
+	return strings.Join([]string{svc.Domain, svc.Project}, datasource.SPLIT)
 }

--- a/datasource/mongo/sd/servicec_test.go
+++ b/datasource/mongo/sd/servicec_test.go
@@ -71,7 +71,8 @@ func TestServiceCacheBasicFunc(t *testing.T) {
 		DocumentID: "id2",
 		Value:      svc2,
 	}
-	t.Run("update&&delete serviceCache, should pass", func(t *testing.T) {
+
+	t.Run("add serviceCache, should pass", func(t *testing.T) {
 		serviceCache.cache.ProcessUpdate(event1)
 		assert.Equal(t, serviceCache.cache.Size(), 1)
 		assert.Nil(t, serviceCache.cache.Get("id_not_exist"))
@@ -82,6 +83,32 @@ func TestServiceCacheBasicFunc(t *testing.T) {
 		assert.Len(t, serviceCache.cache.GetValue("default/default/appid1/svc1/1.0"), 2)
 		assert.Len(t, serviceCache.cache.GetValue("default/default/987654321"), 1)
 		assert.Len(t, serviceCache.cache.GetValue("default/default/123456789"), 1)
+
+	})
+
+	t.Run("update serviceCache, should pass", func(t *testing.T) {
+		assert.Equal(t, svc1, serviceCache.cache.Get("id1").(model.Service))
+		var svc1Update = model.Service{
+			Domain:  "default",
+			Project: "default",
+			Tags:    nil,
+			Service: &discovery.MicroService{
+				ServiceId:   "123456789",
+				AppId:       "appid1",
+				ServiceName: "svc1",
+				Version:     "1.0",
+				Description: "update",
+			},
+		}
+		eventUpdate := MongoEvent{
+			DocumentID: "id1",
+			Value:      svc1Update,
+		}
+		serviceCache.cache.ProcessUpdate(eventUpdate)
+		assert.Equal(t, svc1Update, serviceCache.cache.Get("id1").(model.Service))
+	})
+
+	t.Run("delete serviceCache, should pass", func(t *testing.T) {
 		serviceCache.cache.ProcessDelete(event1)
 		assert.Nil(t, serviceCache.cache.Get("id1"))
 		assert.Len(t, serviceCache.cache.GetValue("default/default/appid1/svc1/1.0"), 1)

--- a/datasource/mongo/util.go
+++ b/datasource/mongo/util.go
@@ -21,8 +21,6 @@ import (
 	"context"
 
 	"github.com/apache/servicecomb-service-center/datasource"
-	"github.com/apache/servicecomb-service-center/datasource/mongo/client/dao"
-	mutil "github.com/apache/servicecomb-service-center/datasource/mongo/util"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	pb "github.com/go-chassis/cari/discovery"
 	"github.com/go-chassis/foundation/gopool"
@@ -49,9 +47,7 @@ func statistics(ctx context.Context, withShared bool) (*pb.Statistics, error) {
 		Apps:      &pb.StApp{},
 	}
 
-	filter := mutil.NewBasicFilter(ctx)
-
-	services, err := dao.GetMicroServices(ctx, filter)
+	services, err := GetAllMicroServicesByDomainProject(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +64,7 @@ func statistics(ctx context.Context, withShared bool) (*pb.Statistics, error) {
 		getInstanceCountByDomain(ctx, svcIDToNonVerKey, respGetInstanceCountByDomain)
 	})
 
-	instances, err := dao.GetInstances(ctx, filter)
+	instances, err := GetInstances(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -88,11 +84,8 @@ func statistics(ctx context.Context, withShared bool) (*pb.Statistics, error) {
 
 func getInstanceCountByDomain(ctx context.Context, svcIDToNonVerKey map[string]string, resp chan datasource.GetInstanceCountByDomainResponse) {
 	ret := datasource.GetInstanceCountByDomainResponse{}
-	domain := util.ParseDomain(ctx)
-	project := util.ParseProject(ctx)
 	for sid := range svcIDToNonVerKey {
-		filter := mutil.NewDomainProjectFilter(domain, project, mutil.InstanceServiceID(sid))
-		num, err := dao.CountInstance(ctx, filter)
+		num, err := CountInstance(ctx, sid)
 		if err != nil {
 			ret.Err = err
 			return


### PR DESCRIPTION
【issue】: #1066

【特性/模块名称】：缓存查询优化

【修改内容】：
1.所有查询service/instance/dep的地方都由从db查询修改为先从缓存中查询，如果缓存中没有再查db
根据version版本匹配的地方暂未修改，后续实现了缓存version匹配再修改

2.service/instance/的index由原来的{serviceID}修改为{domain}/{project}/{serviceID}的形式
否则多域下出现serviceID相同的情况查询会有问题

【自测情况】：
测试通过