### PR TITLE
Feature: Add authentication resource scope

### DIFF
--- a/docs/user-guides/rbac.md
+++ b/docs/user-guides/rbac.md
@@ -1,7 +1,7 @@
 # RBAC
-Beta feature. 
 
-you can choose to enable RBAC feature, after enable RBAC, all request to service center must be authenticated
+you can choose to enable RBAC feature, after enable RBAC, 
+all request to service center must be authenticated
 
 ### Configuration file
 Follow steps to enable this feature.

--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -153,6 +153,7 @@ rbac:
   privateKeyFile: ./private.key
   publicKeyFile: ./public.key
   releaseLockAfter: 15m # failure login attempt causes account blocking, that is block duration
+  scope: '*' # specify auth resource scope, can be account,role,service,service/schema,...
 metrics:
   # enable to start metrics gather
   enable: true

--- a/server/handler/auth/auth.go
+++ b/server/handler/auth/auth.go
@@ -32,18 +32,13 @@ import (
 	"github.com/apache/servicecomb-service-center/server/response"
 )
 
-const (
-	CtxResourceLabels util.CtxKey = "_resource_labels"
-	CtxResourceScopes util.CtxKey = "_resource_scopes"
-)
+const CtxResourceLabels util.CtxKey = "_resource_labels"
 
 type Handler struct {
 }
 
 func (h *Handler) Handle(i *chain.Invocation) {
 	r := i.Context().Value(rest.CtxRequest).(*http.Request)
-
-	i.WithContext(CtxResourceScopes, auth.ResourceScopes(r))
 
 	if err := auth.Identify(r); err != nil {
 		log.Errorf(err, "authenticate request failed, %s %s", r.Method, r.RequestURI)

--- a/server/plugin/auth/auth.go
+++ b/server/plugin/auth/auth.go
@@ -27,9 +27,6 @@ const AUTH plugin.Kind = "auth"
 
 type Authenticate interface {
 	Identify(r *http.Request) error
-	// ResourceScopes return the scope parsed from request
-	// return nil mean apply all resources
-	ResourceScopes(r *http.Request) *ResourceScope
 }
 
 func Auth() Authenticate {
@@ -38,8 +35,4 @@ func Auth() Authenticate {
 
 func Identify(r *http.Request) error {
 	return Auth().Identify(r)
-}
-
-func ResourceScopes(r *http.Request) *ResourceScope {
-	return Auth().ResourceScopes(r)
 }

--- a/server/plugin/auth/buildin/buildin.go
+++ b/server/plugin/auth/buildin/buildin.go
@@ -49,6 +49,7 @@ func (ba *TokenAuthenticator) Identify(req *http.Request) error {
 	if !rbacsvc.Enabled() {
 		return nil
 	}
+
 	pattern, ok := req.Context().Value(rest.CtxMatchPattern).(string)
 	if !ok {
 		pattern = req.URL.Path
@@ -140,8 +141,8 @@ func checkPerm(roleList []string, project string, req *http.Request, apiPattern,
 		return true, nil, nil
 	}
 	//todo fast check for dev role
-	targetResource, ok := req.Context().Value(authHandler.CtxResourceScopes).(*auth.ResourceScope)
-	if !ok || targetResource == nil {
+	targetResource := FromRequest(req)
+	if targetResource == nil {
 		return false, nil, errors.New("no valid resouce scope")
 	}
 	//TODO add project
@@ -153,11 +154,4 @@ func mustAuth(pattern string) bool {
 		return false
 	}
 	return rbac.MustAuth(pattern)
-}
-
-func (ba *TokenAuthenticator) ResourceScopes(r *http.Request) *auth.ResourceScope {
-	if !rbacsvc.Enabled() {
-		return nil
-	}
-	return FromRequest(r)
 }

--- a/server/plugin/auth/buildin/buildin.go
+++ b/server/plugin/auth/buildin/buildin.go
@@ -29,7 +29,7 @@ import (
 	authHandler "github.com/apache/servicecomb-service-center/server/handler/auth"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth"
 	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
-	"github.com/go-chassis/cari/rbac"
+	rbacmodel "github.com/go-chassis/cari/rbac"
 	"github.com/go-chassis/go-chassis/v2/security/authr"
 	"github.com/go-chassis/go-chassis/v2/server/restful"
 )
@@ -56,7 +56,7 @@ func (ba *TokenAuthenticator) Identify(req *http.Request) error {
 		log.Warn("can not find api pattern")
 	}
 
-	if !mustAuth(pattern) {
+	if !rbacsvc.MustAuth(pattern) {
 		return nil
 	}
 
@@ -68,10 +68,10 @@ func (ba *TokenAuthenticator) Identify(req *http.Request) error {
 
 	m, ok := claims.(map[string]interface{})
 	if !ok {
-		log.Error("claims convert failed", rbac.ErrConvertErr)
-		return rbac.ErrConvertErr
+		log.Error("claims convert failed", rbacmodel.ErrConvertErr)
+		return rbacmodel.ErrConvertErr
 	}
-	account, err := rbac.GetAccount(m)
+	account, err := rbacmodel.GetAccount(m)
 	if err != nil {
 		log.Error("get account from token failed", err)
 		return err
@@ -93,14 +93,14 @@ func (ba *TokenAuthenticator) Identify(req *http.Request) error {
 		return err
 	}
 	if !allow {
-		return rbac.NewError(rbac.ErrNoPermission, "")
+		return rbacmodel.NewError(rbacmodel.ErrNoPermission, "")
 	}
 
 	util.SetRequestContext(req, authHandler.CtxResourceLabels, matchedLabels)
 	return nil
 }
 
-func isChangeSelfPassword(pattern string, a *rbac.Account, req *http.Request) bool {
+func isChangeSelfPassword(pattern string, a *rbacmodel.Account, req *http.Request) bool {
 	if pattern != rbacsvc.APIAccountPassword {
 		return false
 	}
@@ -111,7 +111,7 @@ func isChangeSelfPassword(pattern string, a *rbac.Account, req *http.Request) bo
 
 func filterRoles(roleList []string) (hasAdmin bool, normalRoles []string) {
 	for _, r := range roleList {
-		if r == rbac.RoleAdmin {
+		if r == rbacmodel.RoleAdmin {
 			hasAdmin = true
 			return
 		}
@@ -123,11 +123,11 @@ func filterRoles(roleList []string) (hasAdmin bool, normalRoles []string) {
 func (ba *TokenAuthenticator) VerifyToken(req *http.Request) (interface{}, error) {
 	v := req.Header.Get(restful.HeaderAuth)
 	if v == "" {
-		return nil, rbac.NewError(rbac.ErrNoAuthHeader, "")
+		return nil, rbacmodel.NewError(rbacmodel.ErrNoAuthHeader, "")
 	}
 	s := strings.Split(v, " ")
 	if len(s) != 2 {
-		return nil, rbac.ErrInvalidHeader
+		return nil, rbacmodel.ErrInvalidHeader
 	}
 	to := s[1]
 
@@ -147,11 +147,4 @@ func checkPerm(roleList []string, project string, req *http.Request, apiPattern,
 	}
 	//TODO add project
 	return rbacsvc.Allow(req.Context(), project, normalRoles, targetResource)
-}
-
-func mustAuth(pattern string) bool {
-	if util.IsVersionOrHealthPattern(pattern) {
-		return false
-	}
-	return rbac.MustAuth(pattern)
 }

--- a/server/plugin/auth/buildin/buildin_test.go
+++ b/server/plugin/auth/buildin/buildin_test.go
@@ -25,17 +25,17 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	_ "github.com/apache/servicecomb-service-center/test"
+
 	"github.com/apache/servicecomb-service-center/pkg/rest"
 	"github.com/apache/servicecomb-service-center/pkg/util"
-	"github.com/go-chassis/cari/pkg/errsvc"
-	"github.com/go-chassis/cari/rbac"
-
 	"github.com/apache/servicecomb-service-center/server/config"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth/buildin"
 	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
-	_ "github.com/apache/servicecomb-service-center/test"
 	"github.com/astaxie/beego"
+	"github.com/go-chassis/cari/pkg/errsvc"
 	carirbac "github.com/go-chassis/cari/rbac"
+	rbacmodel "github.com/go-chassis/cari/rbac"
 	"github.com/go-chassis/go-archaius"
 	"github.com/go-chassis/go-chassis/v2/security/authr"
 	"github.com/go-chassis/go-chassis/v2/security/secret"
@@ -108,10 +108,10 @@ func TestTokenAuthenticator_Identify(t *testing.T) {
 		assert.NoError(t, err)
 	})
 	t.Run("valid normal token, should no be able to get account", func(t *testing.T) {
-		a := &rbac.Account{
+		a := &rbacmodel.Account{
 			Name:     "non-admin",
 			Password: "Complicated_password1",
-			Roles:    []string{rbac.RoleDeveloper},
+			Roles:    []string{rbacmodel.RoleDeveloper},
 		}
 		err := rbacsvc.CreateAccount(context.TODO(), a)
 		assert.NoError(t, err)
@@ -147,8 +147,6 @@ func TestTokenAuthenticator_Identify(t *testing.T) {
 
 	t.Run("TestTokenAuthenticator_ResourceScopes", func(t *testing.T) {
 		url := "/v4/accounts/:name"
-		a := buildin.New()
-		ta := a.(*buildin.TokenAuthenticator)
 
 		tests := []struct {
 			name     string
@@ -169,7 +167,7 @@ func TestTokenAuthenticator_Identify(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				util.SetRequestContext(tt.request, rest.CtxMatchPattern, url)
-				scopes := ta.ResourceScopes(tt.request)
+				scopes := buildin.FromRequest(tt.request)
 				assert.NotNil(t, scopes)
 				assert.Equal(t, tt.wantType, scopes.Type)
 				assert.Equal(t, tt.wantVerb, scopes.Verb)

--- a/server/plugin/auth/buildin/parser.go
+++ b/server/plugin/auth/buildin/parser.go
@@ -49,6 +49,8 @@ func ApplyAll(r *http.Request) (*auth.ResourceScope, error) {
 	}, nil
 }
 
+// FromRequest return the scope parsed from request
+// return nil mean apply all resources
 func FromRequest(r *http.Request) *auth.ResourceScope {
 	apiPath, ok := r.Context().Value(rest.CtxMatchPattern).(string)
 	if !ok {

--- a/server/plugin/auth/buildin/parser_test.go
+++ b/server/plugin/auth/buildin/parser_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth/buildin"
-	"github.com/apache/servicecomb-service-center/server/service/rbac"
+	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
 	"github.com/go-chassis/cari/discovery"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAPIParseFunc(t *testing.T) {
-	rbac.InitResourceMap()
+	rbacsvc.InitResourceMap()
 
 	var serviceIDA, serviceIDB string
 

--- a/server/resource/register.go
+++ b/server/resource/register.go
@@ -21,7 +21,6 @@ import (
 	roa "github.com/apache/servicecomb-service-center/pkg/rest"
 	v1 "github.com/apache/servicecomb-service-center/server/resource/v1"
 	v4 "github.com/apache/servicecomb-service-center/server/resource/v4"
-	"github.com/apache/servicecomb-service-center/server/service/rbac"
 )
 
 func init() {
@@ -29,9 +28,7 @@ func init() {
 }
 
 func initRouter() {
-	if rbac.Enabled() {
-		roa.RegisterServant(&v4.AuthResource{})
-		roa.RegisterServant(&v4.RoleResource{})
-	}
+	roa.RegisterServant(&v4.AuthResource{})
+	roa.RegisterServant(&v4.RoleResource{})
 	roa.RegisterServant(&v1.Governance{})
 }

--- a/server/resource/register.go
+++ b/server/resource/register.go
@@ -21,6 +21,7 @@ import (
 	roa "github.com/apache/servicecomb-service-center/pkg/rest"
 	v1 "github.com/apache/servicecomb-service-center/server/resource/v1"
 	v4 "github.com/apache/servicecomb-service-center/server/resource/v4"
+	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
 )
 
 func init() {
@@ -28,7 +29,9 @@ func init() {
 }
 
 func initRouter() {
-	roa.RegisterServant(&v4.AuthResource{})
-	roa.RegisterServant(&v4.RoleResource{})
+	if rbacsvc.Enabled() {
+		roa.RegisterServant(&v4.AuthResource{})
+		roa.RegisterServant(&v4.RoleResource{})
+	}
 	roa.RegisterServant(&v1.Governance{})
 }

--- a/server/service/rbac/account_service.go
+++ b/server/service/rbac/account_service.go
@@ -22,15 +22,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-chassis/cari/discovery"
-	"github.com/go-chassis/cari/rbac"
-
 	"github.com/apache/servicecomb-service-center/datasource"
 	errorsEx "github.com/apache/servicecomb-service-center/pkg/errors"
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	"github.com/apache/servicecomb-service-center/server/plugin/quota"
 	"github.com/apache/servicecomb-service-center/server/service/validator"
+	"github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/cari/rbac"
 )
 
 //CreateAccount save 2 kv

--- a/server/service/rbac/context.go
+++ b/server/service/rbac/context.go
@@ -29,9 +29,6 @@ import (
 const CtxRequestClaims util.CtxKey = "_request_claims"
 
 func UserFromContext(ctx context.Context) string {
-	if !Enabled() {
-		return AccountRoot.Name
-	}
 	m, ok := ctx.Value(CtxRequestClaims).(map[string]interface{})
 	if !ok {
 		return ""
@@ -44,10 +41,6 @@ func UserFromContext(ctx context.Context) string {
 }
 
 func AccountFromContext(ctx context.Context) (*rbacmodel.Account, error) {
-	if !Enabled() {
-		a := AccountRoot
-		return &a, nil
-	}
 	m, ok := ctx.Value(CtxRequestClaims).(map[string]interface{})
 	if !ok {
 		return nil, errors.New("no claims from request context")

--- a/server/service/rbac/context.go
+++ b/server/service/rbac/context.go
@@ -29,6 +29,9 @@ import (
 const CtxRequestClaims util.CtxKey = "_request_claims"
 
 func UserFromContext(ctx context.Context) string {
+	if !Enabled() {
+		return AccountRoot.Name
+	}
 	m, ok := ctx.Value(CtxRequestClaims).(map[string]interface{})
 	if !ok {
 		return ""
@@ -41,6 +44,10 @@ func UserFromContext(ctx context.Context) string {
 }
 
 func AccountFromContext(ctx context.Context) (*rbacmodel.Account, error) {
+	if !Enabled() {
+		a := AccountRoot
+		return &a, nil
+	}
 	m, ok := ctx.Value(CtxRequestClaims).(map[string]interface{})
 	if !ok {
 		return nil, errors.New("no claims from request context")


### PR DESCRIPTION
当前enbleRBAC控制了2个特性的开关：
1. API的认证鉴权
1. Account、Role的API是否注册到路由

这就表示，必须开启认证才能进行accout和role的规划维护，这样对于生产环境开启安全认证，用户只能选择中断业务或被迫全部使用root来达到平滑切换目的，现在打算这样解决：
1. 在开启rbac时，增加一个resource scope的概念，用于指定认证鉴权的资源范围，支持*表示默认鉴权所有资源。
1. 在切换时先设置scope=account,role，保证其他资源不受影响，等维护好account和对应的role权限，并进行分发给SDK侧配置认证信息后，再更新scope=*可以达到平滑开启的效果。
1. 支持开启rbac，不传初始化root密码跳过root账号创建，支持通过private key签发root的token，调用API创建root账号
