### PR TITLE
Bug: continue if parse value failed

### DIFF
--- a/datasource/etcd/state/etcd/indexer_etcd.go
+++ b/datasource/etcd/state/etcd/indexer_etcd.go
@@ -44,7 +44,7 @@ func (i *Indexer) CheckPrefix(key string) error {
 	return nil
 }
 
-func (i *Indexer) Search(ctx context.Context, opts ...etcdadpt.OpOption) (r *kvstore.Response, err error) {
+func (i *Indexer) Search(ctx context.Context, opts ...etcdadpt.OpOption) (*kvstore.Response, error) {
 	op := etcdadpt.OpGet(opts...)
 	key := util.BytesToStringWithNoCopy(op.Key)
 
@@ -59,10 +59,10 @@ func (i *Indexer) Search(ctx context.Context, opts ...etcdadpt.OpOption) (r *kvs
 		return nil, err
 	}
 
-	r = new(kvstore.Response)
+	r := new(kvstore.Response)
 	r.Count = resp.Count
 	if len(resp.Kvs) == 0 || op.CountOnly {
-		return
+		return r, nil
 	}
 
 	p := i.Parser
@@ -73,13 +73,13 @@ func (i *Indexer) Search(ctx context.Context, opts ...etcdadpt.OpOption) (r *kvs
 	kvs := make([]*kvstore.KeyValue, 0, len(resp.Kvs))
 	for _, src := range resp.Kvs {
 		kv := kvstore.NewKeyValue()
-		if err = FromEtcdKeyValue(kv, src, p); err != nil {
+		if err := FromEtcdKeyValue(kv, src, p); err != nil {
 			continue
 		}
 		kvs = append(kvs, kv)
 	}
 	r.Kvs = kvs
-	return
+	return r, nil
 }
 
 // Creditable implements kvstore.Indexer#Creditable.

--- a/datasource/etcd/state/parser/parser.go
+++ b/datasource/etcd/state/parser/parser.go
@@ -37,8 +37,8 @@ var (
 	MapParser    = New(newMap, MapUnmarshal)
 
 	UnParse ParseValueFunc = func(src []byte, dist interface{}) error {
-		if err := check(src, dist); err != nil {
-			return err
+		if dist == nil {
+			return ErrTargetNilPoint
 		}
 		d := dist.(*interface{})
 		*d = src

--- a/datasource/etcd/value/parser_test.go
+++ b/datasource/etcd/value/parser_test.go
@@ -17,67 +17,47 @@
 package value
 
 import (
-	"github.com/apache/servicecomb-service-center/datasource/etcd/state/parser"
 	"testing"
 
+	"github.com/apache/servicecomb-service-center/datasource/etcd/state/parser"
 	"github.com/go-chassis/cari/discovery"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestParseInnerValueTypeFunc(t *testing.T) {
 	r, err := parser.BytesParser.Unmarshal(nil)
-	if err == nil {
-		t.Fatalf("BytesParser.Unmarshal failed")
-	}
+	assert.NoError(t, err)
+	assert.Nil(t, r.([]byte))
+
 	r, err = parser.BytesParser.Unmarshal([]byte("a"))
-	if err != nil {
-		t.Fatalf("BytesParser.Unmarshal failed, %s", err.Error())
-	}
-	if v, ok := r.([]byte); !ok || v[0] != 'a' {
-		t.Fatalf("BytesParser.Unmarshal failed, %s", v)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("a"), r.([]byte))
 
 	r, err = parser.StringParser.Unmarshal(nil)
-	if err != nil {
-		t.Fatalf("StringParser.Unmarshal failed")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "", r.(string))
+
 	r, err = parser.StringParser.Unmarshal([]byte("abc"))
-	if err != nil {
-		t.Fatalf("StringParser.Unmarshal failed, %s", err.Error())
-	}
-	if v, ok := r.(string); !ok || v != "abc" {
-		t.Fatalf("StringParser.Unmarshal failed, %s", v)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", r.(string))
 
 	r, err = parser.MapParser.Unmarshal(nil)
-	if err == nil {
-		t.Fatalf("MapParser.Unmarshal failed")
-	}
+	assert.ErrorIs(t, parser.ErrParseNilPoint, err)
+
 	r, err = parser.MapParser.Unmarshal([]byte(`{"a": "abc"}`))
-	if err != nil {
-		t.Fatalf("MapParser.Unmarshal failed, %s", err.Error())
-	}
-	if v, ok := r.(map[string]string); !ok || v["a"] != "abc" {
-		t.Fatalf("MapParser.Unmarshal failed, %s", v)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{"a": "abc"}, r.(map[string]string))
 
 	r, err = parser.MapParser.Unmarshal([]byte(`xxx`))
-	if err == nil {
-		t.Fatalf("MapParser.Unmarshal failed")
-	}
+	assert.Error(t, err)
 
 	var m interface{} = new(discovery.MicroService)
 	err = parser.JSONUnmarshal(nil, nil)
-	if err == nil {
-		t.Fatalf("JSONUnmarshal failed")
-	}
+	assert.ErrorIs(t, parser.ErrParseNilPoint, err)
+
 	err = parser.JSONUnmarshal([]byte(`{"serviceName": "abc"}`), &m)
-	if err != nil {
-		t.Fatalf("MapParser.Unmarshal failed, %v", err)
-	}
-	if m.(*discovery.MicroService).ServiceName != "abc" {
-		t.Fatalf("MapParser.Unmarshal failed, %s", m)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, "abc", m.(*discovery.MicroService).ServiceName)
 }
 
 func TestParseValueTypeFunc(t *testing.T) {


### PR DESCRIPTION
场景：当KV存储的数据原类型为[]byte，string时，解析器会认为nil是非法结果，导致解析失败
解决方案：当解析器遇到nil，原类型[]byte应解析成nil，string解析成""