### PR TITLE
[fix] modify ci to use mongo replica set

### DIFF
--- a/.github/workflows/eventbase-ci.yml
+++ b/.github/workflows/eventbase-ci.yml
@@ -9,16 +9,12 @@ jobs:
         with:
           go-version: 1.16
         id: go
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.7.0
-        with:
-          mongodb-version: 4.2
-          mongodb-replica-set: test-rs
-          mongodb-port: 27017
       - name: Check out source code
         uses: actions/checkout@v1
       - name: UT test
         run: |
+          sudo docker-compose -f ./scripts/docker-compose.yaml up -d
+          sleep 20
           export TEST_DB_MODE=mongo
           export TEST_DB_URI=mongodb://127.0.0.1:27017
           cd eventbase
@@ -31,7 +27,7 @@ jobs:
         with:
           go-version: 1.16
         id: go
-      - name: Check out code into the Go module directory
+      - name: Check out source code
         uses: actions/checkout@v1
       - name: UT for etcd
         run: |

--- a/.github/workflows/static_check.yml
+++ b/.github/workflows/static_check.yml
@@ -40,6 +40,8 @@ jobs:
         uses: actions/checkout@v1
       - name: UT-MONGO
         run: |
+          sudo docker-compose -f ./scripts/docker-compose.yaml up -d
+          sleep 20
           bash -x scripts/ut_test_in_docker.sh mongo
   integration-test:
     runs-on: ubuntu-latest

--- a/scripts/docker-compose.yaml
+++ b/scripts/docker-compose.yaml
@@ -1,0 +1,28 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+version: '3.3'
+services:
+  mongo:
+    image: mongo:4.2
+    command: mongod --replSet my-replica-set --port 27017 --bind_ip_all
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_DATABASE: servicecomb
+    healthcheck:
+      test: test $$(echo "rs.initiate({_id:'my-replica-set',members:[{_id:0,host:\"127.0.0.1:27017\"}]}).ok || rs.status().ok" | mongo --port 27017 --quiet) -eq 1
+      interval: 10s

--- a/scripts/ut_test_in_docker.sh
+++ b/scripts/ut_test_in_docker.sh
@@ -44,8 +44,6 @@ if [ ${db_name} == "etcd" ];then
   done
   echo "${green}Etcd is running......${reset}"
 elif [ ${db_name} == "mongo" ];then
-  echo "${green}Starting mongo in docker${reset}"
-  docker run -d -p 27017:27017 --name mongo mongo
   while ! nc -z 127.0.0.1 27017; do
     echo "Waiting mongo to launch on 27017..."
     sleep 1


### PR DESCRIPTION
【修改内容】：修改 mongo 的 ci，开启副本集
【修改原因】：之前 mongo ci 测试用例副本集没有开启，还有 apache 这边只能支持 apache 自身拥有权限的 ci action，所以这边使用docker-compose
【影响范围】：无
【额外说明】：无
【测试用例】：无
