### PR TITLE
[fix] distinguish creating and updating dep tasks

### DIFF
--- a/datasource/etcd/dep.go
+++ b/datasource/etcd/dep.go
@@ -165,9 +165,15 @@ func (dm *DepManager) AddOrUpdateDependencies(ctx context.Context, dependencyInf
 	}
 
 	if datasource.EnableSync {
-		taskOpt, err := GenTaskOpts("", "", sync.UpdateAction, datasource.ResourceDependency, dependencyInfos)
+		action := sync.UpdateAction
+		if override {
+			action = sync.CreateAction
+		}
+		domain := util.ParseDomain(ctx)
+		project := util.ParseProject(ctx)
+		taskOpt, err := GenTaskOpts(domain, project, action, datasource.ResourceDependency, dependencyInfos)
 		if err != nil {
-			log.Error("", err)
+			log.Error("fail to create task", err)
 			return pb.CreateResponse(pb.ErrInternal, err.Error()), err
 		}
 		opts = append(opts, taskOpt)


### PR DESCRIPTION
【issue】#1196
【修改内容】：根据接口的 override的状态确认其dep资源task任务的状态，true 表示 create，false表示update，具体接口看[链接1](https://github.com/apache/servicecomb-service-center/blob/160431cbf8d33644cbd526e496b1a0554de0afd8/server/service/disco/dependency.go#L29) 和[链接2](https://github.com/apache/servicecomb-service-center/blob/160431cbf8d33644cbd526e496b1a0554de0afd8/server/service/disco/dependency.go#L41)
【修改原因】：修复上一个[PR](https://github.com/apache/servicecomb-service-center/pull/1200)，只有update dep task的状态，应该有两个状态，create和update
【影响范围】：无
【额外说明】：无
【测试用例】：
开启同步任务：
1、创建一个consumer和两个Provider服务，consumer先去创建订阅Provider，会创建一个create类型的同步任务
2、consumer然后再去订阅第二个Provider，会创建一个update类型的同步任务