### PR TITLE
[feat] add microservice sync func and ut when db mode is etcd

### DIFF
--- a/datasource/common.go
+++ b/datasource/common.go
@@ -35,6 +35,7 @@ const (
 	ResourceAccount    = "account"
 	ResourceRole       = "role"
 	ResourceDependency = "dependency"
+	ResourceService    = "service"
 )
 
 // WrapErrResponse is temp func here to wait finish to refact the discosvc pkg

--- a/datasource/etcd/ms_test.go
+++ b/datasource/etcd/ms_test.go
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except request compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to request writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package etcd_test
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/cari/sync"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/eventbase/model"
+	"github.com/apache/servicecomb-service-center/eventbase/service/task"
+	"github.com/apache/servicecomb-service-center/eventbase/service/tombstone"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+)
+
+func microServiceGetContext() context.Context {
+	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-micro-service",
+		"sync-micro-service"))
+}
+
+func TestSyncMicroService(t *testing.T) {
+	datasource.EnableSync = true
+
+	var serviceID string
+
+	t.Run("register micro-service", func(t *testing.T) {
+		t.Run("register a micro service will create a task should pass", func(t *testing.T) {
+			resp, err := datasource.GetMetadataManager().RegisterService(microServiceGetContext(), &pb.CreateServiceRequest{
+				Service: &pb.MicroService{
+					AppId:       "sync_micro_service_group",
+					ServiceName: "sync_micro_service",
+					Version:     "1.0.0",
+					Level:       "FRONT",
+					Status:      pb.MS_UP,
+				},
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+			serviceID = resp.ServiceId
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.CreateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(context.Background(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("update micro-service", func(t *testing.T) {
+		t.Run("update a micro service setting sync-test property will create a task should pass", func(t *testing.T) {
+			request := &pb.UpdateServicePropsRequest{
+				ServiceId:  serviceID,
+				Properties: make(map[string]string),
+			}
+			request.Properties["sync-test"] = "sync-test"
+			resp, err := datasource.GetMetadataManager().UpdateService(microServiceGetContext(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.UpdateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(context.Background(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("unregister micro-service", func(t *testing.T) {
+		t.Run("unregister a micro service will create a task and a tombstone should pass", func(t *testing.T) {
+			resp, err := datasource.GetMetadataManager().UnregisterService(microServiceGetContext(), &pb.DeleteServiceRequest{
+				ServiceId: serviceID,
+				Force:     true,
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.DeleteAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(context.Background(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+			tombstoneListReq := model.ListTombstoneRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+			}
+			tombstones, err := tombstone.List(context.Background(), &tombstoneListReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tombstones))
+			err = tombstone.Delete(context.Background(), tombstones...)
+			assert.NoError(t, err)
+		})
+	})
+
+	datasource.EnableSync = false
+}


### PR DESCRIPTION
【issue】#1196
【修改内容】：当开启同步接口后，创建、更新、删除service都会创建相应类型的task，删除服务时还会创建相应的tombstone
【修改原因】：同步任务功能需要
【影响范围】：无
【额外说明】：无
【测试用例】：
开启同步任务：
1、创建 microservice，会创建一个create 状态以及service资源类型的 task
2、更新这个服务，会创建一个update状态以及service资源类型的 task
3、删除这个服务，会创建一个delete状态以及service资源类型的task，还有一个tombstone