### PR TITLE
[feat] add datacenter info to instance from config

### DIFF
--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -144,6 +144,10 @@ registry:
     # the allowable minimum value of instance heartbeat interval
     # if interval < minInterval, instance TTL still set with minInterval
     minInterval: 5s
+    datacenter:
+      name:
+      region:
+      availableZone:
 
   schema:
     # if want disable Test Schema, SchemaDisable set true

--- a/server/core/microservice.go
+++ b/server/core/microservice.go
@@ -74,6 +74,17 @@ func InitRegistration() {
 			Times:    RegistryDefaultLeaseRetryTimes,
 		},
 	}
+
+	name := config.GetString("registry.instance.datacenter.name", " ")
+	region := config.GetString("registry.instance.datacenter.region", " ")
+	availableZone := config.GetString("registry.instance.datacenter.availableZone", " ")
+	if len(name) > 0 && len(region) > 0 && len(availableZone) > 0 {
+		Instance.DataCenterInfo = &discovery.DataCenterInfo{
+			Name:          name,
+			Region:        region,
+			AvailableZone: availableZone,
+		}
+	}
 }
 
 func AddDefaultContextValue(ctx context.Context) context.Context {


### PR DESCRIPTION
【issue】#1207
【修改内容】：config增加datacenter 信息，获取实例的时候读取配置信息 
【修改原因】：获取实例接口增加datacenter 信息
【影响范围】：无
【额外说明】：无
【测试用例】：无