### PR TITLE
[fix] fix test cases for services and dependencies when the db mode is etcd

### DIFF
--- a/datasource/etcd/ms_test.go
+++ b/datasource/etcd/ms_test.go
@@ -64,12 +64,12 @@ func TestSyncMicroService(t *testing.T) {
 				Action:       sync.CreateAction,
 				Status:       sync.PendingStatus,
 			}
-			tasks, err := task.List(context.Background(), &listTaskReq)
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(microServiceGetContext(), tasks...)
 			assert.NoError(t, err)
-			tasks, err = task.List(context.Background(), &listTaskReq)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(tasks))
 		})
@@ -92,12 +92,12 @@ func TestSyncMicroService(t *testing.T) {
 				Action:       sync.UpdateAction,
 				Status:       sync.PendingStatus,
 			}
-			tasks, err := task.List(context.Background(), &listTaskReq)
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(microServiceGetContext(), tasks...)
 			assert.NoError(t, err)
-			tasks, err = task.List(context.Background(), &listTaskReq)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(tasks))
 		})
@@ -119,12 +119,12 @@ func TestSyncMicroService(t *testing.T) {
 				Action:       sync.DeleteAction,
 				Status:       sync.PendingStatus,
 			}
-			tasks, err := task.List(context.Background(), &listTaskReq)
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(microServiceGetContext(), tasks...)
 			assert.NoError(t, err)
-			tasks, err = task.List(context.Background(), &listTaskReq)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, len(tasks))
 			tombstoneListReq := model.ListTombstoneRequest{
@@ -135,7 +135,7 @@ func TestSyncMicroService(t *testing.T) {
 			tombstones, err := tombstone.List(context.Background(), &tombstoneListReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(tombstones))
-			err = tombstone.Delete(context.Background(), tombstones...)
+			err = tombstone.Delete(microServiceGetContext(), tombstones...)
 			assert.NoError(t, err)
 		})
 	})


### PR DESCRIPTION
【issue】#1196
【修改内容】：
1、dep用例将创建的 task 任务和tombstone都删除，以免给后面用例带来影响
2、ms用例中将context.Background()修改成microServiceGetContext()指定的上下文
【修改原因】：
1、sync同步功能事务落盘
【影响范围】：无
【额外说明】：无
【测试用例】：做修复，见修改内容