### PR TITLE
[feat] normal access traffic needs to be synchronized

### DIFF
--- a/datasource/etcd/account.go
+++ b/datasource/etcd/account.go
@@ -192,12 +192,12 @@ func (ds *RbacDAO) DeleteAccount(ctx context.Context, names []string) (bool, err
 			continue //do not fail if some account is invalid
 
 		}
+		allOpts = append(allOpts, opts...)
 		syncOpts, err := esync.GenDeleteOpts(ctx, datasource.ResourceAccount, a.Name, a)
 		if err != nil {
 			log.Error("fail to create sync opts", err)
 			return false, err
 		}
-		allOpts = append(allOpts, opts...)
 		allOpts = append(allOpts, syncOpts...)
 	}
 	err := etcdadpt.Txn(ctx, allOpts)

--- a/datasource/etcd/dep_test.go
+++ b/datasource/etcd/dep_test.go
@@ -34,11 +34,11 @@ import (
 )
 
 func depGetContext() context.Context {
-	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-dep", "sync-dep"))
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-dep", "sync-dep"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
 }
 
 func TestSyncAddOrUpdateDependencies(t *testing.T) {
-	datasource.EnableSync = true
 	var (
 		consumerId  string
 		providerId1 string
@@ -242,5 +242,4 @@ func TestSyncAddOrUpdateDependencies(t *testing.T) {
 			assert.Equal(t, 0, len(tombstones))
 		})
 	})
-	datasource.EnableSync = false
 }

--- a/datasource/etcd/ms.go
+++ b/datasource/etcd/ms.go
@@ -543,14 +543,14 @@ func (ds *MetadataManager) registerInstance(ctx context.Context, request *pb.Reg
 			instanceFlag, instanceID, remoteIP), nil)
 		return "", pb.NewError(pb.ErrServiceNotExists, "Service does not exist.")
 	}
-	sendEvent(sync.CreateAction, datasource.ResourceInstance, request)
+	sendEvent(ctx, sync.CreateAction, datasource.ResourceInstance, request)
 	log.Info(fmt.Sprintf("register instance %s, instanceID %s, operator %s",
 		instanceFlag, instanceID, remoteIP))
 	return instanceID, nil
 }
 
-func sendEvent(action string, resourceType string, resource interface{}) {
-	if !datasource.EnableSync {
+func sendEvent(ctx context.Context, action string, resourceType string, resource interface{}) {
+	if !util.EnableSync(ctx) {
 		return
 	}
 	event.Publish(action, resourceType, resource)
@@ -904,8 +904,7 @@ func (ds *MetadataManager) PutInstanceStatus(ctx context.Context, request *pb.Up
 		log.Error(fmt.Sprintf("update instance[%s] status failed", updateStatusFlag), err)
 		return err
 	}
-
-	sendEvent(sync.UpdateAction, datasource.ResourceInstance, copyInstanceRef)
+	sendEvent(ctx, sync.UpdateAction, datasource.ResourceInstance, copyInstanceRef)
 	log.Info(fmt.Sprintf("update instance[%s] status successfully", updateStatusFlag))
 	return nil
 }
@@ -932,7 +931,7 @@ func (ds *MetadataManager) PutInstanceProperties(ctx context.Context, request *p
 		return err
 	}
 
-	sendEvent(sync.UpdateAction, datasource.ResourceInstance, copyInstanceRef)
+	sendEvent(ctx, sync.UpdateAction, datasource.ResourceInstance, copyInstanceRef)
 	log.Info(fmt.Sprintf("update instance[%s] properties successfully", instanceFlag))
 	return nil
 }
@@ -965,7 +964,7 @@ func (ds *MetadataManager) SendManyHeartbeat(ctx context.Context, request *pb.He
 		}
 	}
 	log.Info(fmt.Sprintf("batch update heartbeats, %v", instanceHbRstArr))
-	sendEvent(sync.UpdateAction, datasource.ResourceHeartbeatSet, request)
+	sendEvent(ctx, sync.UpdateAction, datasource.ResourceHeartbeatSet, request)
 	return &pb.HeartbeatSetResponse{
 		Instances: instanceHbRstArr,
 	}, nil
@@ -985,7 +984,7 @@ func (ds *MetadataManager) UnregisterInstance(ctx context.Context, request *pb.U
 			instanceFlag, remoteIP), err)
 		return err
 	}
-	sendEvent(sync.DeleteAction, datasource.ResourceInstance, request)
+	sendEvent(ctx, sync.DeleteAction, datasource.ResourceInstance, request)
 	log.Info(fmt.Sprintf("unregister instance[%s], operator %s", instanceFlag, remoteIP))
 	return nil
 }
@@ -1009,7 +1008,7 @@ func (ds *MetadataManager) SendHeartbeat(ctx context.Context, request *pb.Heartb
 		log.Info(fmt.Sprintf("heartbeat successful, renew instance[%s] ttl to %d. operator %s",
 			instanceFlag, ttl, remoteIP))
 	}
-	sendEvent(sync.UpdateAction, datasource.ResourceHeartbeat, request)
+	sendEvent(ctx, sync.UpdateAction, datasource.ResourceHeartbeat, request)
 	return nil
 }
 

--- a/datasource/etcd/ms_test.go
+++ b/datasource/etcd/ms_test.go
@@ -33,13 +33,12 @@ import (
 )
 
 func microServiceGetContext() context.Context {
-	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-micro-service",
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-micro-service",
 		"sync-micro-service"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
 }
 
 func TestSyncMicroService(t *testing.T) {
-	datasource.EnableSync = true
-
 	var serviceID string
 
 	t.Run("register micro-service", func(t *testing.T) {
@@ -138,6 +137,4 @@ func TestSyncMicroService(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
-
-	datasource.EnableSync = false
 }

--- a/datasource/etcd/schema.go
+++ b/datasource/etcd/schema.go
@@ -158,6 +158,7 @@ func (dao *SchemaDAO) DeleteRef(ctx context.Context, refRequest *schema.RefReque
 		etcdadpt.OpDel(etcdadpt.WithStrKey(refKey)),
 		etcdadpt.OpDel(etcdadpt.WithStrKey(summaryKey)),
 	}
+
 	refOpts, err := sync.GenDeleteOpts(ctx, datasource.ResourceKV, refKey, refKey)
 	if err != nil {
 		log.Error("fail to create delete opts", err)
@@ -253,10 +254,8 @@ func (dao *SchemaDAO) PutContent(ctx context.Context, contentRequest *schema.Put
 		existContentOptions = append(existContentOptions,
 			etcdadpt.OpPut(etcdadpt.WithStrKey(serviceKey), etcdadpt.WithValue(body)))
 	}
-
 	newContentOptions := append(existContentOptions,
-		etcdadpt.OpPut(etcdadpt.WithStrKey(contentKey), etcdadpt.WithStrValue(content.Content)),
-	)
+		etcdadpt.OpPut(etcdadpt.WithStrKey(contentKey), etcdadpt.WithStrValue(content.Content)))
 	contentOpts, err := sync.GenUpdateOpts(ctx, datasource.ResourceKV, content.Content, sync.WithOpts(map[string]string{"key": contentKey}))
 	if err != nil {
 		log.Error("fail to create update opts", err)
@@ -350,7 +349,6 @@ func transformSchemaIDsAndOptions(ctx context.Context, domainProject string, ser
 			log.Error("fail to create update opts", err)
 		}
 		options = append(options, summaryOpts...)
-
 		schemaIDs = append(schemaIDs, schemaID)
 		pendingDeleteSchemaIDs.Remove(schemaID)
 	}

--- a/datasource/etcd/schema_test.go
+++ b/datasource/etcd/schema_test.go
@@ -35,12 +35,12 @@ import (
 )
 
 func schemaContext() context.Context {
-	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-schema", "sync-schema"))
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-schema", "sync-schema"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
 }
 
 func TestSyncSchema(t *testing.T) {
 
-	datasource.EnableSync = true
 	var serviceID string
 
 	defer schema.Instance().DeleteContent(schemaContext(), &schema.ContentRequest{
@@ -111,10 +111,10 @@ func TestSyncSchema(t *testing.T) {
 				ResourceType: datasource.ResourceKV,
 				Status:       csync.PendingStatus,
 			}
-			tasks, err := task.List(context.Background(), &listTaskReq)
+			tasks, err := task.List(schemaContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 3, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(schemaContext(), tasks...)
 			assert.NoError(t, err)
 		})
 	})
@@ -162,10 +162,10 @@ func TestSyncSchema(t *testing.T) {
 				ResourceType: datasource.ResourceKV,
 				Status:       csync.PendingStatus,
 			}
-			tasks, err := task.List(context.Background(), &listTaskReq)
+			tasks, err := task.List(schemaContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 7, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(schemaContext(), tasks...)
 			assert.NoError(t, err)
 			listTaskReq = model.ListTaskRequest{
 				Domain:       "sync-schema",
@@ -174,20 +174,20 @@ func TestSyncSchema(t *testing.T) {
 				ResourceType: datasource.ResourceKV,
 				Status:       csync.PendingStatus,
 			}
-			tasks, err = task.List(context.Background(), &listTaskReq)
+			tasks, err = task.List(schemaContext(), &listTaskReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(tasks))
-			err = task.Delete(context.Background(), tasks...)
+			err = task.Delete(schemaContext(), tasks...)
 			assert.NoError(t, err)
 			tombstoneListReq := model.ListTombstoneRequest{
 				Domain:       "sync-schema",
 				Project:      "sync-schema",
 				ResourceType: datasource.ResourceKV,
 			}
-			tombstones, err := tombstone.List(context.Background(), &tombstoneListReq)
+			tombstones, err := tombstone.List(schemaContext(), &tombstoneListReq)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, len(tombstones))
-			err = tombstone.Delete(context.Background(), tombstones...)
+			err = tombstone.Delete(schemaContext(), tombstones...)
 			assert.NoError(t, err)
 		})
 	})
@@ -275,6 +275,4 @@ func TestSyncSchema(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
-
-	datasource.EnableSync = false
 }

--- a/datasource/etcd/sync/sync.go
+++ b/datasource/etcd/sync/sync.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-chassis/cari/sync"
 	"github.com/little-cui/etcdadpt"
 
-	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/eventbase/datasource/etcd/key"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 )
@@ -71,7 +70,7 @@ func GenDeleteOpts(ctx context.Context, resourceType, resourceID string, resourc
 
 func genOpts(ctx context.Context, action string, resourceType string, resource interface{},
 	options ...Option) ([]etcdadpt.OpOptions, error) {
-	if !datasource.EnableSync {
+	if !util.EnableSync(ctx) {
 		return nil, nil
 	}
 	syncOpts := NewSyncOptions()

--- a/datasource/etcd/sync/sync_test.go
+++ b/datasource/etcd/sync/sync_test.go
@@ -30,13 +30,12 @@ import (
 )
 
 func optsContext() context.Context {
-	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-opts",
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-opts",
 		"sync-opts"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
 }
 
 func TestOpts(t *testing.T) {
-	datasource.EnableSync = true
-
 	t.Run("create func will create a task opt should pass", func(t *testing.T) {
 		opts, err := sync.GenCreateOpts(optsContext(), datasource.ResourceService, &pb.CreateServiceRequest{})
 		assert.Nil(t, err)
@@ -54,5 +53,4 @@ func TestOpts(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, 2, len(opts))
 	})
-	datasource.EnableSync = false
 }

--- a/datasource/etcd/tag_test.go
+++ b/datasource/etcd/tag_test.go
@@ -34,13 +34,12 @@ import (
 )
 
 func tagContext() context.Context {
-	return util.WithNoCache(util.SetDomainProject(context.Background(), "sync-tag",
-		"sync-tag"))
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-tag", "sync-tag"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
 }
 
 func TestSyncTag(t *testing.T) {
 	var serviceID string
-	datasource.EnableSync = true
 	t.Run("create service", func(t *testing.T) {
 		t.Run("register a micro service will create a task should pass", func(t *testing.T) {
 			resp, err := datasource.GetMetadataManager().RegisterService(tagContext(), &pb.CreateServiceRequest{
@@ -208,6 +207,4 @@ func TestSyncTag(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	})
-
-	datasource.EnableSync = false
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -28,6 +28,7 @@ const (
 	CtxCacheOnly        CtxKey = "cacheOnly"
 	CtxRequestRevision  CtxKey = "requestRev"
 	CtxResponseRevision CtxKey = "responseRev"
+	CtxEnableSync       CtxKey = "enableSync"
 )
 
 func GetAppRoot() string {

--- a/pkg/util/context.go
+++ b/pkg/util/context.go
@@ -217,6 +217,10 @@ func Global(ctx context.Context) bool {
 	return ctx.Value(CtxGlobal) == "1"
 }
 
+func EnableSync(ctx context.Context) bool {
+	return ctx.Value(CtxEnableSync) == "1"
+}
+
 func WithRequestRev(ctx context.Context, rev string) context.Context {
 	return SetContext(ctx, CtxRequestRevision, rev)
 }

--- a/server/handler/context/context.go
+++ b/server/handler/context/context.go
@@ -20,6 +20,7 @@ package context
 import (
 	"net/http"
 
+	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/pkg/chain"
 	"github.com/apache/servicecomb-service-center/pkg/rest"
 	"github.com/apache/servicecomb-service-center/pkg/util"
@@ -46,6 +47,10 @@ func (c *Handler) Handle(i *chain.Invocation) {
 		v3.Write(r)
 	case v4.IsMatch(r):
 		v4.Write(r)
+	}
+
+	if datasource.EnableSync {
+		i.WithContext(util.CtxEnableSync, "1")
 	}
 
 	c.commonQueryToContext(i)


### PR DESCRIPTION
【issue】#1196
【修改内容】：
1、修改拦截器，若sc开启同步开关，则正常流量访问需要落盘同步，同步请求访问service不需要进行落盘
【修改原因】：
1、sync同步功能事务落盘
【影响范围】：无
【额外说明】：开启同步开关，正常业务流量访问需要落盘，同步请求不需要进行落盘
【测试用例】：
1、测试用例做了部分修改，主要还是在ctx里传入了开启同步的配置