### PR TITLE
[feat] add engine info to instance

### DIFF
--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -148,6 +148,8 @@ registry:
       name:
       region:
       availableZone:
+    # properties params for instance
+    properties:
 
   schema:
     # if want disable Test Schema, SchemaDisable set true

--- a/server/config/util.go
+++ b/server/config/util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/go-chassis/go-archaius"
 	"github.com/iancoleman/strcase"
+	"github.com/spf13/cast"
 )
 
 func newOptions(key string, opts []Option) *Options {
@@ -87,6 +88,36 @@ func GetInt64(key string, def int64, opts ...Option) int64 {
 		return archaius.GetInt64(key, def)
 	}
 	return beego.AppConfig.DefaultInt64(options.Standby, def)
+}
+
+func GetStringMap(key string) map[string]string {
+	result := make(map[string]string)
+	getMapFunc(key, func(k string, value interface{}) {
+		result[k] = cast.ToString(value)
+	})
+	return result
+}
+
+func getMapFunc(key string, dataFunc func(k string, v interface{})) {
+	configs := archaius.GetConfigs()
+	keyPoint := key + "."
+	for k, v := range configs {
+		if !strings.HasPrefix(k, keyPoint) {
+			continue
+		}
+
+		keys := strings.Split(k, keyPoint)
+		keysLen := len(keys)
+		if keysLen != 2 {
+			continue
+		}
+
+		kk := keys[keysLen-1]
+		if strings.Contains(kk, ".") {
+			continue
+		}
+		dataFunc(kk, v)
+	}
 }
 
 // GetDuration return the time.Duration type value by specified key

--- a/server/config/util_test.go
+++ b/server/config/util_test.go
@@ -20,6 +20,7 @@ package config_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/apache/servicecomb-service-center/pkg/util"
@@ -35,4 +36,56 @@ func TestGetString(t *testing.T) {
 		archaius.WithOptionalFiles([]string{filepath.Join(util.GetAppRoot(), "conf", "app.yaml")}))
 	assert.Equal(t, "test", config.GetString("test.getString", "none"))
 	assert.Equal(t, "test", config.GetString("other.getString", "none", config.WithENV("TEST_GET_STRING")))
+}
+
+func TestGetStringMap(t *testing.T) {
+	changeConfigPath()
+	os.Setenv("TEST_GET_STRING", "test")
+	defer archaius.Clean()
+	archaius.Init(archaius.WithMemorySource(), archaius.WithENVSource(),
+		archaius.WithOptionalFiles([]string{filepath.Join(util.GetAppRoot(), "conf", "app.yaml")}))
+
+	t.Run("has no data from config should be passed", func(t *testing.T) {
+		_ = archaius.Set("a.b.c", "test_value_c")
+		_ = archaius.Set("a.b.d", "test_value_d")
+		maps := config.GetStringMap("a.c")
+		assert.Equal(t, 0, len(maps))
+	})
+	archaius.Clean()
+	t.Run("has same key , should be passed", func(t *testing.T) {
+		_ = archaius.Set("a.b.c", "test_value_c")
+		_ = archaius.Set("a.bb.d", "test_value_d")
+		maps := config.GetStringMap("a.b")
+		assert.Equal(t, 1, len(maps))
+		c, ok := maps["c"]
+		assert.Equal(t, true, ok)
+		assert.Equal(t, "test_value_c", c)
+	})
+	archaius.Clean()
+	t.Run("has first value, should be passed", func(t *testing.T) {
+		_ = archaius.Set("a.b.c", "test_value_c")
+		_ = archaius.Set("a.b.d", "test_value_d")
+		maps := config.GetStringMap("a")
+		assert.Equal(t, 0, len(maps))
+	})
+	archaius.Clean()
+	t.Run("value type is different, should be passed", func(t *testing.T) {
+		_ = archaius.Set("aa.b.c", 1)
+		_ = archaius.Set("aa.b.d", "test_value_d")
+		maps := config.GetStringMap("aa.b")
+		assert.Equal(t, 2, len(maps))
+		c, ok1 := maps["c"]
+		d, ok2 := maps["d"]
+		assert.Equal(t, true, ok1 && ok2)
+		assert.Equal(t, "1", c)
+		assert.Equal(t, "test_value_d", d)
+	})
+
+}
+
+func changeConfigPath() {
+	workDir, _ := os.Getwd()
+	replacePath := filepath.Join("server", "config")
+	workDir = strings.ReplaceAll(workDir, replacePath, "etc")
+	os.Setenv("APP_ROOT", workDir)
 }

--- a/server/service/disco/instance_test.go
+++ b/server/service/disco/instance_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/servicecomb-service-center/server/config"
 	"github.com/apache/servicecomb-service-center/server/core"
 	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
+	_ "github.com/apache/servicecomb-service-center/test"
 	pb "github.com/go-chassis/cari/discovery"
 	"github.com/go-chassis/cari/pkg/errsvc"
 	"github.com/stretchr/testify/assert"
@@ -383,6 +384,27 @@ func TestRegisterInstance(t *testing.T) {
 		testErr = err.(*errsvc.Error)
 		assert.Error(t, testErr)
 		assert.Equal(t, pb.ErrInvalidParams, testErr.Code)
+	})
+
+	t.Run(" register properties info to instance, should be passed", func(t *testing.T) {
+		instance := &pb.MicroServiceInstance{
+			ServiceId: serviceId1,
+			Endpoints: []string{
+				"sameInstance:127.0.0.1:8080",
+			},
+			HostName: "UT-HOST",
+			Status:   pb.MSI_UP,
+		}
+		_, err := discosvc.RegisterInstance(ctx, &pb.RegisterInstanceRequest{
+			Instance: instance,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(instance.Properties))
+		engineID, ok1 := instance.Properties["engineID"]
+		engineName, ok2 := instance.Properties["engineName"]
+		assert.Equal(t, true, ok1 && ok2)
+		assert.Equal(t, "test_engineID", engineID)
+		assert.Equal(t, "test_engineName", engineName)
 	})
 }
 

--- a/test/test.go
+++ b/test/test.go
@@ -41,6 +41,8 @@ func init() {
 	var kind = "etcd"
 	var uri = "http://127.0.0.1:2379"
 	_ = archaius.Set("rbac.releaseLockAfter", "3s")
+	_ = archaius.Set("registry.instance.properties.engineID", "test_engineID")
+	_ = archaius.Set("registry.instance.properties.engineName", "test_engineName")
 	if IsETCD() {
 		_ = archaius.Set("registry.cache.mode", 0)
 		_ = archaius.Set("discovery.kind", "etcd")


### PR DESCRIPTION
【issue】#1219
【修改内容】：配置中增加实例的引擎信息，注册实例的时候加上配置的引擎信息
【修改原因】：增加引擎信息到实例中去
【影响范围】：无
【额外说明】：无
【测试用例】：无
