### PR TITLE
Bug: return internal properties when list all microservices

### DIFF
--- a/datasource/etcd/etcd.go
+++ b/datasource/etcd/etcd.go
@@ -94,7 +94,11 @@ func NewDataSource(opts datasource.Options) (datasource.DataSource, error) {
 	if err := inst.initialize(); err != nil {
 		return nil, err
 	}
-	inst.metadataManager = newMetadataManager(opts.SchemaNotEditable, opts.InstanceTTL)
+	inst.metadataManager = &MetadataManager{
+		SchemaNotEditable:  opts.SchemaNotEditable,
+		InstanceTTL:        opts.InstanceTTL,
+		InstanceProperties: opts.InstanceProperties,
+	}
 	inst.sysManager = newSysManager()
 	inst.depManager = &DepManager{}
 	inst.scManager = &SCManager{}

--- a/datasource/mongo/mongo.go
+++ b/datasource/mongo/mongo.go
@@ -74,7 +74,11 @@ func NewDataSource(opts datasource.Options) (datasource.DataSource, error) {
 	inst.scManager = &SCManager{}
 	inst.depManager = &DepManager{}
 	inst.sysManager = &SysManager{}
-	inst.metadataManager = &MetadataManager{SchemaNotEditable: opts.SchemaNotEditable, InstanceTTL: opts.InstanceTTL}
+	inst.metadataManager = &MetadataManager{
+		SchemaNotEditable:  opts.SchemaNotEditable,
+		InstanceTTL:        opts.InstanceTTL,
+		InstanceProperties: opts.InstanceProperties,
+	}
 	inst.metricsManager = &MetricsManager{}
 	return inst, nil
 }

--- a/datasource/options.go
+++ b/datasource/options.go
@@ -28,5 +28,6 @@ type Options struct {
 	EnableCache       bool
 	SchemaNotEditable bool
 	// InstanceTTL: the default ttl of instance lease
-	InstanceTTL int64
+	InstanceTTL        int64
+	InstanceProperties map[string]string
 }

--- a/server/server.go
+++ b/server/server.go
@@ -124,9 +124,10 @@ func (s *ServiceCenterServer) initDatasource() {
 				}
 			},
 		},
-		EnableCache:       config.GetRegistry().EnableCache,
-		InstanceTTL:       config.GetRegistry().InstanceTTL,
-		SchemaNotEditable: config.GetRegistry().SchemaNotEditable,
+		EnableCache:        config.GetRegistry().EnableCache,
+		SchemaNotEditable:  config.GetRegistry().SchemaNotEditable,
+		InstanceTTL:        config.GetRegistry().InstanceTTL,
+		InstanceProperties: config.GetStringMap("registry.instance.properties"),
 	}); err != nil {
 		log.Fatal("init datasource failed", err)
 	}


### PR DESCRIPTION
背景：管控面接口-返回所有微服务实例信息，由于考虑返回body体大小的原因，将properties属性禁止输出了；此优化与内置实例属性的需求矛盾，需求要求返回properties内置的属性。
修改方案：如存在内置属性，仅输出内置属性，自定义属性依然在微服务详情接口中返回

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `go build` `go test` `go fmt` `go vet` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
 - [ ] Never comment source code, delete it.
 - [ ] UT should has "context, subject, expected result" result as test case name, when you call t.Run().
---
