### PR TITLE
[feat] eventbase use db kind

### DIFF
--- a/eventbase/README.md
+++ b/eventbase/README.md
@@ -16,18 +16,38 @@ eventbase provides the crud interface of task and tombstone.
 
 ### how to use
 
-1.First you should import the eventbase's bootstrap
+1.First you should initialize db
+
+```go
+import (
+    _ "github.com/go-chassis/cari/db/bootstrap"
+    "github.com/go-chassis/cari/db"
+)
+
+func Init(){
+    cfg := config.Config{
+    Kind: "etcd",
+    URI: "http://127.0.0.1:2379",
+    Timeout: 10 * time.Second,
+    }
+    err := db.Init(&cfg)
+}
+```
+
+
+2.Second you should import the eventbase's bootstrap
 ```go
 import (
     _ "github.com/apache/servicecomb-service-center/eventbase/bootstrap"
 )
 ```
-2.Second you should do Init func
+3.Third you should do Init func
 
 ```go
 
 import (
     "github.com/go-chassis/cari/db/config"
+    "github.com/go-chassis/cari/db"
     
     _ "github.com/apache/servicecomb-service-center/eventbase/bootstrap"
     "github.com/apache/servicecomb-service-center/eventbase/datasource"
@@ -41,7 +61,8 @@ func main(){
 		URI: "http://127.0.0.1:2379",
 		Timeout: 10 * time.Second,
 	}
-	err := datasource.Init(&cfg)
+	err := db.Init(&cfg)
+	err = datasource.Init("etcd")
 	...
 	tasksvc.List(...)
 	tombstonesvc.List(...)

--- a/eventbase/bootstrap/bootstrap.go
+++ b/eventbase/bootstrap/bootstrap.go
@@ -18,8 +18,6 @@
 package bootstrap
 
 import (
-	_ "github.com/go-chassis/cari/db/bootstrap"
-
 	_ "github.com/apache/servicecomb-service-center/eventbase/datasource/etcd"
 	_ "github.com/apache/servicecomb-service-center/eventbase/datasource/mongo"
 )

--- a/eventbase/datasource/manager.go
+++ b/eventbase/datasource/manager.go
@@ -19,15 +19,6 @@ package datasource
 
 import (
 	"fmt"
-	"time"
-
-	"github.com/go-chassis/cari/db"
-	"github.com/go-chassis/cari/db/config"
-)
-
-const (
-	DefaultTimeout = 60 * time.Second
-	DefaultDBKind  = "embedded_etcd"
 )
 
 var (
@@ -45,20 +36,10 @@ func RegisterPlugin(name string, engineFunc dataSourceEngine) {
 	plugins[name] = engineFunc
 }
 
-func Init(c *config.Config) error {
-	if c.Kind == "" {
-		c.Kind = DefaultDBKind
-	}
-	if c.Timeout == 0 {
-		c.Timeout = DefaultTimeout
-	}
-	err := db.Init(c)
-	if err != nil {
-		return err
-	}
-	f, ok := plugins[c.Kind]
+func Init(kind string) error {
+	f, ok := plugins[kind]
 	if !ok {
-		return fmt.Errorf("do not support %s", c.Kind)
+		return fmt.Errorf("do not support %s", kind)
 	}
 	dataSourceInst = f()
 	return nil

--- a/eventbase/datasource/manager_test.go
+++ b/eventbase/datasource/manager_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestInit(t *testing.T) {
 	t.Run("init config should pass with no error", func(t *testing.T) {
-		err := datasource.Init(&test.DbCfg)
+		err := datasource.Init(test.DBKind)
 		assert.Nil(t, err)
 		assert.NotNil(t, datasource.GetDataSource())
 	})

--- a/eventbase/service/task/task_svc_test.go
+++ b/eventbase/service/task/task_svc_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func init() {
-	err := datasource.Init(&test.DbCfg)
+	err := datasource.Init(test.DBKind)
 	if err != nil {
 		panic(err)
 	}

--- a/eventbase/service/tombstone/tombstone_svc_test.go
+++ b/eventbase/service/tombstone/tombstone_svc_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	err := datasource.Init(&test.DbCfg)
+	err := datasource.Init(test.DBKind)
 	if err != nil {
 		panic(err)
 	}

--- a/eventbase/test/test.go
+++ b/eventbase/test/test.go
@@ -20,10 +20,12 @@ package test
 import (
 	"time"
 
+	"github.com/go-chassis/cari/db"
 	"github.com/go-chassis/cari/db/config"
 	"github.com/go-chassis/go-archaius"
 
 	_ "github.com/apache/servicecomb-service-center/eventbase/bootstrap"
+	_ "github.com/go-chassis/cari/db/bootstrap"
 )
 
 var (
@@ -35,9 +37,10 @@ var (
 	DefaultTestDBURI = "http://127.0.0.1:2379"
 )
 
-var DbCfg = config.Config{}
+var DBKind string
 
 func init() {
+	cfg := config.Config{}
 	err := archaius.Init(archaius.WithMemorySource(), archaius.WithENVSource())
 	if err != nil {
 		panic(err)
@@ -50,7 +53,12 @@ func init() {
 	if ok {
 		DefaultTestDBURI = uri
 	}
-	DbCfg.Kind = DefaultTestDB
-	DbCfg.URI = DefaultTestDBURI
-	DbCfg.Timeout = 10 * time.Second
+	DBKind = DefaultTestDB
+	cfg.Kind = DefaultTestDB
+	cfg.URI = DefaultTestDBURI
+	cfg.Timeout = 10 * time.Second
+	err = db.Init(&cfg)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/syncer/service/tombstone/tombstone_test.go
+++ b/syncer/service/tombstone/tombstone_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func init() {
-	err := datasource.Init(&test.DbCfg)
+	err := datasource.Init(test.DBKind)
 	if err != nil {
 		panic(err)
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-chassis/cari/db"
 	"github.com/go-chassis/cari/db/config"
 	"github.com/go-chassis/go-archaius"
 	"github.com/little-cui/etcdadpt"
@@ -30,7 +31,7 @@ import (
 
 	_ "github.com/apache/servicecomb-service-center/eventbase/bootstrap"
 	_ "github.com/apache/servicecomb-service-center/server/bootstrap"
-	_ "github.com/apache/servicecomb-service-center/server/init"
+	_ "github.com/go-chassis/cari/db/bootstrap"
 	_ "github.com/go-chassis/go-chassis-extension/protocol/grpc/server"
 
 	"github.com/apache/servicecomb-service-center/datasource"
@@ -64,11 +65,13 @@ func init() {
 	})
 	_ = metrics.Init(metrics.Options{})
 
-	_ = edatasource.Init(&config.Config{
+	_ = db.Init(&config.Config{
 		Kind:    kind,
 		URI:     uri,
 		Timeout: 10 * time.Second,
 	})
+
+	_ = edatasource.Init(kind)
 
 	_ = registry.SelfRegister(context.Background())
 }


### PR DESCRIPTION
【issue】#1227
【修改内容】：
1.使用 cari 连接db的 clint，[cari修改地址](https://github.com/go-chassis/cari/pull/52)
2.event需要传入kind的db类型，前提需要保证db已经初始化好了
【修改原因】：
1、减少db的client创建
【影响范围】：无
【额外说明】：无
【测试用例】：无