### PR TITLE
[feat] add task tombstone when db is mongo

### DIFF
--- a/datasource/mongo/account_test.go
+++ b/datasource/mongo/account_test.go
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"context"
+	"testing"
+
+	crbac "github.com/go-chassis/cari/rbac"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/rbac"
+	"github.com/apache/servicecomb-service-center/eventbase/model"
+	"github.com/apache/servicecomb-service-center/eventbase/service/task"
+	"github.com/apache/servicecomb-service-center/eventbase/service/tombstone"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	_ "github.com/apache/servicecomb-service-center/test"
+)
+
+func accountContext() context.Context {
+	return util.WithNoCache(util.SetContext(context.Background(), util.CtxEnableSync, "1"))
+}
+
+func TestSyncAccount(t *testing.T) {
+
+	t.Run("create account", func(t *testing.T) {
+		t.Run("creating a account then delete it will create two tasks and a tombstone should pass",
+			func(t *testing.T) {
+				a1 := crbac.Account{
+					ID:                  "sync-create-11111",
+					Name:                "sync-create-account1",
+					Password:            "tnuocca-tset",
+					Roles:               []string{"admin"},
+					TokenExpirationTime: "2020-12-30",
+					CurrentPassword:     "tnuocca-tset1",
+				}
+				err := rbac.Instance().CreateAccount(accountContext(), &a1)
+				assert.NoError(t, err)
+				r, err := rbac.Instance().GetAccount(accountContext(), a1.Name)
+				assert.NoError(t, err)
+				assert.Equal(t, a1, *r)
+				_, err = rbac.Instance().DeleteAccount(accountContext(), []string{a1.Name})
+				assert.NoError(t, err)
+				listTaskReq := model.ListTaskRequest{
+					Domain:       "",
+					Project:      "",
+					ResourceType: datasource.ResourceAccount,
+				}
+				tasks, err := task.List(accountContext(), &listTaskReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 2, len(tasks))
+				err = task.Delete(accountContext(), tasks...)
+				assert.NoError(t, err)
+				tombstoneListReq := model.ListTombstoneRequest{
+					ResourceType: datasource.ResourceAccount,
+				}
+				tombstones, err := tombstone.List(accountContext(), &tombstoneListReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 1, len(tombstones))
+				err = tombstone.Delete(accountContext(), tombstones...)
+				assert.NoError(t, err)
+			})
+	})
+
+	t.Run("update account", func(t *testing.T) {
+		t.Run("creating two accounts then update them,finally delete them, will create six tasks and two tombstones should pass",
+			func(t *testing.T) {
+				a2 := crbac.Account{
+					ID:                  "sync-update-22222",
+					Name:                "sync-update-account2",
+					Password:            "tnuocca-tset",
+					Roles:               []string{"admin"},
+					TokenExpirationTime: "2020-12-30",
+					CurrentPassword:     "tnuocca-tset",
+				}
+				a3 := crbac.Account{
+					ID:                  "sync-update-33333",
+					Name:                "sync-update-account3",
+					Password:            "tnuocca-tset",
+					Roles:               []string{"admin"},
+					TokenExpirationTime: "2020-12-30",
+					CurrentPassword:     "tnuocca-tset",
+				}
+				err := rbac.Instance().CreateAccount(accountContext(), &a2)
+				assert.NoError(t, err)
+				err = rbac.Instance().CreateAccount(accountContext(), &a3)
+				assert.NoError(t, err)
+				a2.Password = "new-password"
+				err = rbac.Instance().UpdateAccount(accountContext(), a2.Name, &a2)
+				assert.NoError(t, err)
+				a3.Password = "new-password"
+				err = rbac.Instance().UpdateAccount(accountContext(), a3.Name, &a3)
+				assert.NoError(t, err)
+				_, err = rbac.Instance().DeleteAccount(accountContext(), []string{a2.Name, a3.Name})
+				assert.NoError(t, err)
+				listTaskReq := model.ListTaskRequest{
+					Domain:       "",
+					Project:      "",
+					ResourceType: datasource.ResourceAccount,
+				}
+				tasks, err := task.List(accountContext(), &listTaskReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 6, len(tasks))
+				err = task.Delete(accountContext(), tasks...)
+				assert.NoError(t, err)
+				tombstoneListReq := model.ListTombstoneRequest{
+					ResourceType: datasource.ResourceAccount,
+				}
+				tombstones, err := tombstone.List(accountContext(), &tombstoneListReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 2, len(tombstones))
+				err = tombstone.Delete(accountContext(), tombstones...)
+				assert.NoError(t, err)
+
+			})
+	})
+}

--- a/datasource/mongo/db.go
+++ b/datasource/mongo/db.go
@@ -31,6 +31,7 @@ func ensureDB() {
 	ensureInstance()
 	ensureSchema()
 	ensureDep()
+	ensureAccount()
 	ensureAccountLock()
 }
 
@@ -80,6 +81,12 @@ func ensureDep() {
 		model.ColumnDomain,
 		model.ColumnProject,
 		model.ColumnServiceKey)})
+}
+
+func ensureAccount() {
+	dmongo.EnsureCollection(model.CollectionAccount, nil, []mongo.IndexModel{util.BuildIndexDoc(
+		model.ColumnName),
+	})
 }
 
 func ensureAccountLock() {

--- a/datasource/mongo/dep_test.go
+++ b/datasource/mongo/dep_test.go
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/cari/sync"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/eventbase/model"
+	"github.com/apache/servicecomb-service-center/eventbase/service/task"
+	"github.com/apache/servicecomb-service-center/eventbase/service/tombstone"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	_ "github.com/apache/servicecomb-service-center/test"
+)
+
+func depGetContext() context.Context {
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-dep", "sync-dep"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
+}
+
+func TestSyncAddOrUpdateDependencies(t *testing.T) {
+	var (
+		consumerId  string
+		providerId1 string
+		providerId2 string
+	)
+
+	t.Run("register service", func(t *testing.T) {
+		t.Run("create a consumer service will create a service task should pass", func(t *testing.T) {
+			resp, err := datasource.GetMetadataManager().RegisterService(depGetContext(), &pb.CreateServiceRequest{
+				Service: &pb.MicroService{
+					AppId:       "sync_dep_group",
+					ServiceName: "sync_dep_consumer",
+					Version:     "1.0.0",
+					Level:       "FRONT",
+					Status:      pb.MS_UP,
+				},
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			consumerId = resp.ServiceId
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.CreateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(depGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+		t.Run("create two provider services will create two service task should pass", func(t *testing.T) {
+			resp, err := datasource.GetMetadataManager().RegisterService(depGetContext(), &pb.CreateServiceRequest{
+				Service: &pb.MicroService{
+					AppId:       "sync_dep_group",
+					ServiceName: "sync_dep_provider",
+					Version:     "1.0.0",
+					Level:       "FRONT",
+					Status:      pb.MS_UP,
+				},
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			providerId1 = resp.ServiceId
+
+			resp, err = datasource.GetMetadataManager().RegisterService(depGetContext(), &pb.CreateServiceRequest{
+				Service: &pb.MicroService{
+					AppId:       "sync_dep_group",
+					ServiceName: "sync_dep_provider_other",
+					Version:     "1.0.0",
+					Level:       "FRONT",
+					Status:      pb.MS_UP,
+				},
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			providerId2 = resp.ServiceId
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.CreateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(tasks))
+			err = task.Delete(depGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("create dependencies", func(t *testing.T) {
+		t.Run("create dependencies for microServices will create a dependency task should pass", func(t *testing.T) {
+			consumer := &pb.MicroServiceKey{
+				ServiceName: "sync_dep_consumer",
+				AppId:       "sync_dep_group",
+				Version:     "1.0.0",
+			}
+			err := datasource.GetDependencyManager().PutDependencies(depGetContext(), []*pb.ConsumerDependency{
+				{
+					Consumer: consumer,
+					Providers: []*pb.MicroServiceKey{
+						{
+							AppId:       "sync_dep_group",
+							ServiceName: "sync_dep_provider",
+						},
+					},
+				},
+			}, true)
+			assert.NoError(t, err)
+
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceDependency,
+				Action:       sync.CreateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(context.Background(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("add dependencies", func(t *testing.T) {
+		t.Run("add dependencies for microServices will create a dependency task should pass", func(t *testing.T) {
+			consumer := &pb.MicroServiceKey{
+				ServiceName: "sync_dep_consumer",
+				AppId:       "sync_dep_group",
+				Version:     "1.0.0",
+			}
+			err := datasource.GetDependencyManager().PutDependencies(depGetContext(), []*pb.ConsumerDependency{
+				{
+					Consumer: consumer,
+					Providers: []*pb.MicroServiceKey{
+						{
+							AppId:       "sync_dep_group",
+							ServiceName: "sync_dep_provider_other",
+						},
+					},
+				},
+			}, false)
+			assert.NoError(t, err)
+
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceDependency,
+				Action:       sync.UpdateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(context.Background(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(context.Background(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("unregister consumer and provider", func(t *testing.T) {
+		t.Run("unregister consumer and providers will 3 tasks and 3 tombstones should pass", func(t *testing.T) {
+			err := datasource.GetMetadataManager().UnregisterService(depGetContext(), &pb.DeleteServiceRequest{
+				ServiceId: consumerId, Force: true,
+			})
+			assert.NoError(t, err)
+
+			err = datasource.GetMetadataManager().UnregisterService(depGetContext(), &pb.DeleteServiceRequest{
+				ServiceId: providerId1, Force: true,
+			})
+			assert.NoError(t, err)
+
+			err = datasource.GetMetadataManager().UnregisterService(depGetContext(), &pb.DeleteServiceRequest{
+				ServiceId: providerId2, Force: true,
+			})
+			assert.NoError(t, err)
+
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.DeleteAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 3, len(tasks))
+			err = task.Delete(depGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(depGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+			tombstoneListReq := model.ListTombstoneRequest{
+				Domain:       "sync-dep",
+				Project:      "sync-dep",
+				ResourceType: datasource.ResourceService,
+			}
+			tombstones, err := tombstone.List(context.Background(), &tombstoneListReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 3, len(tombstones))
+			err = tombstone.Delete(context.Background(), tombstones...)
+			assert.NoError(t, err)
+			tombstones, err = tombstone.List(context.Background(), &tombstoneListReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tombstones))
+		})
+	})
+}
+

--- a/datasource/mongo/model/types.go
+++ b/datasource/mongo/model/types.go
@@ -36,6 +36,7 @@ const (
 )
 
 const (
+	ColumnName                 = "name"
 	ColumnDomain               = "domain"
 	ColumnProject              = "project"
 	ColumnTag                  = "tags"

--- a/datasource/mongo/ms_test.go
+++ b/datasource/mongo/ms_test.go
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except request compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to request writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"context"
+	"testing"
+
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/cari/sync"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/eventbase/model"
+	"github.com/apache/servicecomb-service-center/eventbase/service/task"
+	"github.com/apache/servicecomb-service-center/eventbase/service/tombstone"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+)
+
+func microServiceGetContext() context.Context {
+	ctx := util.WithNoCache(util.SetDomainProject(context.Background(), "sync-micro-service",
+		"sync-micro-service"))
+	return util.WithNoCache(util.SetContext(ctx, util.CtxEnableSync, "1"))
+}
+
+func TestSyncMicroService(t *testing.T) {
+	var serviceID string
+
+	t.Run("register micro-service", func(t *testing.T) {
+		t.Run("register a micro service will create a task should pass", func(t *testing.T) {
+			resp, err := datasource.GetMetadataManager().RegisterService(microServiceGetContext(), &pb.CreateServiceRequest{
+				Service: &pb.MicroService{
+					AppId:       "sync_micro_service_group",
+					ServiceName: "sync_micro_service",
+					Version:     "1.0.0",
+					Level:       "FRONT",
+					Status:      pb.MS_UP,
+				},
+			})
+			assert.NotNil(t, resp)
+			assert.NoError(t, err)
+			assert.Equal(t, pb.ResponseSuccess, resp.Response.GetCode())
+			serviceID = resp.ServiceId
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.CreateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(microServiceGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("update micro-service", func(t *testing.T) {
+		t.Run("update a micro service setting sync-test property will create a task should pass", func(t *testing.T) {
+			request := &pb.UpdateServicePropsRequest{
+				ServiceId:  serviceID,
+				Properties: make(map[string]string),
+			}
+			request.Properties["sync-test"] = "sync-test"
+			err := datasource.GetMetadataManager().PutServiceProperties(microServiceGetContext(), request)
+			assert.NoError(t, err)
+
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.UpdateAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(microServiceGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+		})
+	})
+
+	t.Run("unregister micro-service", func(t *testing.T) {
+		t.Run("unregister a micro service will create a task and a tombstone should pass", func(t *testing.T) {
+			err := datasource.GetMetadataManager().UnregisterService(microServiceGetContext(), &pb.DeleteServiceRequest{
+				ServiceId: serviceID,
+				Force:     true,
+			})
+			assert.NoError(t, err)
+
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+				Action:       sync.DeleteAction,
+				Status:       sync.PendingStatus,
+			}
+			tasks, err := task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tasks))
+			err = task.Delete(microServiceGetContext(), tasks...)
+			assert.NoError(t, err)
+			tasks, err = task.List(microServiceGetContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 0, len(tasks))
+			tombstoneListReq := model.ListTombstoneRequest{
+				Domain:       "sync-micro-service",
+				Project:      "sync-micro-service",
+				ResourceType: datasource.ResourceService,
+			}
+			tombstones, err := tombstone.List(context.Background(), &tombstoneListReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tombstones))
+			err = tombstone.Delete(microServiceGetContext(), tombstones...)
+			assert.NoError(t, err)
+		})
+	})
+}
+

--- a/datasource/mongo/role_test.go
+++ b/datasource/mongo/role_test.go
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mongo_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	crbac "github.com/go-chassis/cari/rbac"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/rbac"
+	"github.com/apache/servicecomb-service-center/eventbase/model"
+	"github.com/apache/servicecomb-service-center/eventbase/service/task"
+	"github.com/apache/servicecomb-service-center/eventbase/service/tombstone"
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	_ "github.com/apache/servicecomb-service-center/test"
+)
+
+func roleContext() context.Context {
+	return util.WithNoCache(util.SetContext(context.Background(), util.CtxEnableSync, "1"))
+}
+
+func TestSyncRole(t *testing.T) {
+
+	t.Run("create role", func(t *testing.T) {
+		t.Run("creating a role and delete it will create two tasks and a tombstone should pass", func(t *testing.T) {
+			r1 := crbac.Role{
+				ID:    "create-11111",
+				Name:  "create-role",
+				Perms: nil,
+			}
+			err := rbac.Instance().CreateRole(roleContext(), &r1)
+			assert.NoError(t, err)
+			r, err := rbac.Instance().GetRole(roleContext(), "create-role")
+			assert.NoError(t, err)
+			assert.Equal(t, r1, *r)
+			dt, _ := strconv.Atoi(r.CreateTime)
+			assert.Less(t, 0, dt)
+			assert.Equal(t, r.CreateTime, r.UpdateTime)
+			_, err = rbac.Instance().DeleteRole(roleContext(), r1.Name)
+			assert.NoError(t, err)
+			listTaskReq := model.ListTaskRequest{
+				Domain:       "",
+				Project:      "",
+				ResourceType: datasource.ResourceRole,
+			}
+			tasks, err := task.List(roleContext(), &listTaskReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 2, len(tasks))
+			err = task.Delete(roleContext(), tasks...)
+			assert.NoError(t, err)
+			tombstoneListReq := model.ListTombstoneRequest{
+				ResourceType: datasource.ResourceRole,
+			}
+			tombstones, err := tombstone.List(roleContext(), &tombstoneListReq)
+			assert.NoError(t, err)
+			assert.Equal(t, 1, len(tombstones))
+			err = tombstone.Delete(roleContext(), tombstones...)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("update role", func(t *testing.T) {
+		t.Run("create two roles ,then update them, finally delete them, will create six tasks and two tombstones should pass",
+			func(t *testing.T) {
+				r2 := crbac.Role{
+					ID:    "update-22222",
+					Name:  "update-role-22222",
+					Perms: nil,
+				}
+				r3 := crbac.Role{
+					ID:    "update-33333",
+					Name:  "update-role-33333",
+					Perms: nil,
+				}
+				err := rbac.Instance().CreateRole(roleContext(), &r2)
+				assert.NoError(t, err)
+				err = rbac.Instance().CreateRole(roleContext(), &r3)
+				assert.NoError(t, err)
+				r2.ID = "update-22222-33333"
+				err = rbac.Instance().UpdateRole(roleContext(), "update-role-22222", &r2)
+				assert.NoError(t, err)
+				r3.ID = "update-33333-44444"
+				err = rbac.Instance().UpdateRole(roleContext(), "update-role-33333", &r3)
+				assert.NoError(t, err)
+				_, err = rbac.Instance().DeleteRole(roleContext(), r2.Name)
+				assert.NoError(t, err)
+				_, err = rbac.Instance().DeleteRole(roleContext(), r3.Name)
+				assert.NoError(t, err)
+				listTaskReq := model.ListTaskRequest{
+					Domain:       "",
+					Project:      "",
+					ResourceType: datasource.ResourceRole,
+				}
+				tasks, err := task.List(roleContext(), &listTaskReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 6, len(tasks))
+				err = task.Delete(roleContext(), tasks...)
+				assert.NoError(t, err)
+				tombstoneListReq := model.ListTombstoneRequest{
+					ResourceType: datasource.ResourceRole,
+				}
+				tombstones, err := tombstone.List(roleContext(), &tombstoneListReq)
+				assert.NoError(t, err)
+				assert.Equal(t, 2, len(tombstones))
+				err = tombstone.Delete(roleContext(), tombstones...)
+				assert.NoError(t, err)
+
+			})
+	})
+}

--- a/datasource/mongo/sync/sync.go
+++ b/datasource/mongo/sync/sync.go
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sync
+
+import (
+	"context"
+
+	"github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/go-chassis/cari/db/mongo"
+	"github.com/go-chassis/cari/sync"
+)
+
+const (
+	CollectionTask      = "task"
+	CollectionTombstone = "tombstone"
+)
+
+type Options struct {
+	ResourceID string
+	Opts       map[string]string
+}
+
+type Option func(options *Options)
+
+func NewSyncOption() Options {
+	return Options{}
+}
+
+func WithResourceID(resourceID string) Option {
+	return func(options *Options) {
+		options.ResourceID = resourceID
+	}
+}
+
+func WithOpts(opts map[string]string) Option {
+	return func(options *Options) {
+		options.Opts = opts
+	}
+}
+
+func DoCreateOpts(ctx context.Context, resourceType string, resource interface{}, options ...Option) error {
+	return doOpts(ctx, sync.CreateAction, resourceType, resource, options...)
+}
+
+func DoUpdateOpts(ctx context.Context, resourceType string, resource interface{}, options ...Option) error {
+	return doOpts(ctx, sync.UpdateAction, resourceType, resource, options...)
+}
+
+func DoDeleteOpts(ctx context.Context, resourceType, resourceID string, resource interface{}, options ...Option) error {
+	options = append(options, WithResourceID(resourceID))
+	return doOpts(ctx, sync.DeleteAction, resourceType, resource, options...)
+}
+
+func doOpts(ctx context.Context, action string, resourceType string, resource interface{}, options ...Option) error {
+	if !util.EnableSync(ctx) {
+		return nil
+	}
+	syncOpts := NewSyncOption()
+	for _, option := range options {
+		option(&syncOpts)
+	}
+	err := doTaskOpt(ctx, action, resourceType, resource, &syncOpts)
+	if err != nil || action != sync.DeleteAction {
+		return err
+	}
+	return doTombstoneOpt(ctx, resourceType, syncOpts.ResourceID)
+}
+
+func doTaskOpt(ctx context.Context, action string, resourceType string, resource interface{}, syncOpts *Options) error {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	task, err := sync.NewTask(domain, project, action, resourceType, resource)
+	if err != nil {
+		return err
+	}
+	if syncOpts != nil {
+		task.Opts = syncOpts.Opts
+	}
+	_, err = mongo.GetClient().GetDB().Collection(CollectionTask).InsertOne(ctx, task)
+	return err
+}
+
+func doTombstoneOpt(ctx context.Context, resourceType, resourceID string) error {
+	domain := util.ParseDomain(ctx)
+	project := util.ParseProject(ctx)
+	tombstone := sync.NewTombstone(domain, project, resourceType, resourceID)
+	_, err := mongo.GetClient().GetDB().Collection(CollectionTombstone).InsertOne(ctx, tombstone)
+	return err
+}

--- a/eventbase/go.mod
+++ b/eventbase/go.mod
@@ -1,7 +1,7 @@
 module github.com/apache/servicecomb-service-center/eventbase
 
 require (
-	github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d
+	github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7
 	github.com/go-chassis/go-archaius v1.5.4
 	github.com/go-chassis/openlog v1.1.3
 	github.com/little-cui/etcdadpt v0.3.2

--- a/eventbase/go.sum
+++ b/eventbase/go.sum
@@ -112,8 +112,8 @@ github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/
 github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11/go.mod h1:MgtsEI0AM4Ush6Lyw27z9Gk4nQ/8GWTSXrFzupawWDM=
 github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
-github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d h1:RtBn1T7KmJM1j1+NlBFqaKJWPWPDde9adDQMFHCKMbU=
-github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d/go.mod h1:tKTzguHTGohMCgkcWNZWtA4TwfcsJrIXpfYxsQtb7uw=
+github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7 h1:21IJymFsx+TEMY+KwqfyB/no/RpEhN9jld8uALvkU68=
+github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7/go.mod h1:tKTzguHTGohMCgkcWNZWtA4TwfcsJrIXpfYxsQtb7uw=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.2.2/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.3.0/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/deckarep/golang-set v1.7.1
 	github.com/elithrar/simple-scrypt v1.3.0
 	github.com/ghodss/yaml v1.0.0
-	github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d
+	github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7
 	github.com/go-chassis/foundation v0.4.0
 	github.com/go-chassis/go-archaius v1.5.4
 	github.com/go-chassis/go-chassis-extension/protocol/grpc v0.0.0-20210902082902-eb5df922afcd

--- a/go.sum
+++ b/go.sum
@@ -179,14 +179,13 @@ github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11/go.mod h1:MgtsEI0A
 github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
-github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d h1:RtBn1T7KmJM1j1+NlBFqaKJWPWPDde9adDQMFHCKMbU=
-github.com/go-chassis/cari v0.5.1-0.20220119150556-8ae374a2649d/go.mod h1:tKTzguHTGohMCgkcWNZWtA4TwfcsJrIXpfYxsQtb7uw=
+github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7 h1:21IJymFsx+TEMY+KwqfyB/no/RpEhN9jld8uALvkU68=
+github.com/go-chassis/cari v0.5.1-0.20220121124340-cbf87fbeb1d7/go.mod h1:tKTzguHTGohMCgkcWNZWtA4TwfcsJrIXpfYxsQtb7uw=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.2.2/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.3.0/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
 github.com/go-chassis/foundation v0.4.0 h1:z0xETnSxF+vRXWjoIhOdzt6rywjZ4sB++utEl4YgWEY=
 github.com/go-chassis/foundation v0.4.0/go.mod h1:6NsIUaHghTFRGfCBcZN011zl196F6OR5QvD9N+P4oWU=
-github.com/go-chassis/go-archaius v1.5.1 h1:1FrNyzzmD6o6BIjPF8uQ4Cc+u7qYIgQTpDk8uopBqfo=
 github.com/go-chassis/go-archaius v1.5.1/go.mod h1:QPwvvtBxvwiC48rmydoAqxopqOr93RCQ6syWsIkXPXQ=
 github.com/go-chassis/go-archaius v1.5.4 h1:5mGXmBNfYnP8oc5KmXyds3kNMtWqlQ4VQKeyF2lvWs4=
 github.com/go-chassis/go-archaius v1.5.4/go.mod h1:ZyAZzEMPyEsyCP7KLYB/48eX/dDj8CzO/CL87P80AOc=


### PR DESCRIPTION
【issue】#1196
【修改内容】：
1、account事务落盘
2、dep事务落盘
3、role事务落盘
4、ms事务落盘
5、心跳实例发送到event
【修改原因】：
1、sync同步功能
【影响范围】：无
【额外说明】：
1、tag还未落盘
2、schema 对于mongo来说不需要
【测试用例】：
1、复用 etcd 之前写的事务落盘，保障整体功能的可靠性