### PR TITLE
[fix] add SyncAllLockKey in SyncAll func

### DIFF
--- a/datasource/etcd/sync_test.go
+++ b/datasource/etcd/sync_test.go
@@ -63,6 +63,23 @@ func TestSyncAll(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+	t.Run("enableOnstart is true and syncAllKey not exists but SyncAllLockKey is lock will not do sync", func(t *testing.T) {
+		_ = archaius.Set("sync.enableOnStart", true)
+		lock, err := etcdadpt.TryLock(etcd.SyncAllLockKey, 600)
+		assert.Nil(t, err)
+		err = datasource.GetSyncManager().SyncAll(syncAllContext())
+		assert.Nil(t, err)
+		listTaskReq := model.ListTaskRequest{
+			Domain:  "sync-all",
+			Project: "sync-all",
+		}
+		tasks, err := task.List(syncAllContext(), &listTaskReq)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(tasks))
+		err = lock.Unlock()
+		assert.Nil(t, err)
+	})
+
 	t.Run("enableOnStart is true and syncAllKey not exists will do sync", func(t *testing.T) {
 		_ = archaius.Set("sync.enableOnStart", true)
 		var serviceID string


### PR DESCRIPTION
【issue】#1196
【修改内容】：
1、在syncAll的func中添加锁 SyncAllLockKey 的锁
【修改原因】：
1、防止多个 sc 进行重复操作
【影响范围】：无
【额外说明】：无
【测试用例】：
1、先获取SyncAllLockKey的锁，然后执行同步任务，实际不会进行同步