### PR TITLE
[feat] add SyncAll func when db is mongo

### DIFF
--- a/datasource/mongo/db.go
+++ b/datasource/mongo/db.go
@@ -33,6 +33,7 @@ func ensureDB() {
 	ensureDep()
 	ensureAccount()
 	ensureAccountLock()
+	ensureSyncLock()
 }
 
 func ensureService() {
@@ -92,4 +93,9 @@ func ensureAccount() {
 func ensureAccountLock() {
 	dmongo.EnsureCollection(model.CollectionAccountLock, nil, []mongo.IndexModel{
 		util.BuildIndexDoc(model.ColumnAccountLockKey)})
+}
+
+func ensureSyncLock() {
+	dmongo.EnsureCollection(model.CollectionSync, nil, []mongo.IndexModel{
+		util.BuildIndexDoc(model.ColumnKey)})
 }

--- a/datasource/mongo/model/types.go
+++ b/datasource/mongo/model/types.go
@@ -33,6 +33,7 @@ const (
 	CollectionRole        = "role"
 	CollectionDomain      = "domain"
 	CollectionProject     = "project"
+	CollectionSync        = "sync"
 )
 
 const (
@@ -75,6 +76,7 @@ const (
 	ColumnAccountLockKey       = "key"
 	ColumnAccountLockStatus    = "status"
 	ColumnAccountLockReleaseAt = "release_at"
+	ColumnKey                  = "key"
 )
 
 type Service struct {

--- a/datasource/mongo/sync.go
+++ b/datasource/mongo/sync.go
@@ -19,8 +19,25 @@ package mongo
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
+	dmongo "github.com/go-chassis/cari/db/mongo"
+	"github.com/go-chassis/cari/discovery"
+	rbacmodel "github.com/go-chassis/cari/rbac"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/apache/servicecomb-service-center/datasource"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/model"
+	"github.com/apache/servicecomb-service-center/datasource/mongo/sync"
 	"github.com/apache/servicecomb-service-center/pkg/log"
+	putil "github.com/apache/servicecomb-service-center/pkg/util"
+	"github.com/apache/servicecomb-service-center/server/config"
+)
+
+const (
+	SyncAllKey = "sync-all"
 )
 
 type SyncManager struct {
@@ -28,7 +45,171 @@ type SyncManager struct {
 
 // SyncAll will list all services,accounts,roles,schemas,tags,deps and use tasks to store
 func (s *SyncManager) SyncAll(ctx context.Context) error {
-	// TODO mongo should implement it
-	log.Info("Mongo does not implement this method")
+	enable := config.GetBool("sync.enableOnStart", false)
+	if !enable {
+		return nil
+	}
+	exist, err := syncAllKeyExist(ctx)
+	if err != nil {
+		return err
+	}
+	if exist {
+		log.Info(fmt.Sprintf("%s key already exists, do not need to do tasks", SyncAllKey))
+		return datasource.ErrSyncAllKeyExists
+	}
+	// TODO use mongo distributed lock
+	err = syncAllAccounts(ctx)
+	if err != nil {
+		return err
+	}
+	err = syncAllRoles(ctx)
+	if err != nil {
+		return err
+	}
+	err = syncAllServices(ctx)
+	if err != nil {
+		return err
+	}
+	err = syncAllDependencies(ctx)
+	if err != nil {
+		return err
+	}
+	return insertSyncAllKey(ctx)
+}
+
+func syncAllKeyExist(ctx context.Context) (bool, error) {
+	count, err := dmongo.GetClient().GetDB().Collection(model.CollectionSync).CountDocuments(ctx, bson.M{"key": SyncAllKey})
+	if err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return true, nil
+	}
+	return false, nil
+}
+
+func syncAllAccounts(ctx context.Context) error {
+	cursor, err := dmongo.GetClient().GetDB().Collection(model.CollectionAccount).Find(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+	defer func(cursor *mongo.Cursor, ctx context.Context) {
+		err := cursor.Close(ctx)
+		if err != nil {
+			log.Error("fail to close mongo cursor", err)
+		}
+	}(cursor, ctx)
+	for cursor.Next(ctx) {
+		var account rbacmodel.Account
+		err = cursor.Decode(&account)
+		if err != nil {
+			log.Error("failed to decode account", err)
+			return err
+		}
+		err = sync.DoCreateOpts(ctx, datasource.ResourceAccount, &account)
+		if err != nil {
+			log.Error("failed to create account task", err)
+			return err
+		}
+	}
 	return nil
+}
+
+func syncAllRoles(ctx context.Context) error {
+	cursor, err := dmongo.GetClient().GetDB().Collection(model.CollectionRole).Find(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+	defer func(cursor *mongo.Cursor, ctx context.Context) {
+		err := cursor.Close(ctx)
+		if err != nil {
+			log.Error("fail to close mongo cursor", err)
+		}
+	}(cursor, ctx)
+	for cursor.Next(ctx) {
+		var role rbacmodel.Role
+		err = cursor.Decode(&role)
+		if err != nil {
+			log.Error("failed to decode role", err)
+			return err
+		}
+		err = sync.DoCreateOpts(ctx, datasource.ResourceRole, &role)
+		if err != nil {
+			log.Error("failed to create role task", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func syncAllServices(ctx context.Context) error {
+	cursor, err := dmongo.GetClient().GetDB().Collection(model.CollectionService).Find(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+	defer func(cursor *mongo.Cursor, ctx context.Context) {
+		err := cursor.Close(ctx)
+		if err != nil {
+			log.Error("fail to close mongo cursor", err)
+		}
+	}(cursor, ctx)
+	for cursor.Next(ctx) {
+		var tmp model.Service
+		err := cursor.Decode(&tmp)
+		if err != nil {
+			return err
+		}
+		request := &discovery.CreateServiceRequest{
+			Service: tmp.Service,
+			Tags:    tmp.Tags,
+		}
+		putil.SetDomain(ctx, tmp.Domain)
+		putil.SetProject(ctx, tmp.Project)
+		err = sync.DoCreateOpts(ctx, datasource.ResourceService, request)
+		if err != nil {
+			log.Error("failed to create service task", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func syncAllDependencies(ctx context.Context) error {
+	cursor, err := dmongo.GetClient().GetDB().Collection(model.CollectionDep).Find(ctx, bson.M{})
+	if err != nil {
+		return err
+	}
+	depInfosMap := make(map[string][]*discovery.ConsumerDependency)
+	defer func(cursor *mongo.Cursor, ctx context.Context) {
+		err := cursor.Close(ctx)
+		if err != nil {
+			log.Error("fail to close mongo cursor", err)
+		}
+	}(cursor, ctx)
+	for cursor.Next(ctx) {
+		var tmp model.ConsumerDep
+		err := cursor.Decode(&tmp)
+		if err != nil {
+			return err
+		}
+		key := tmp.Domain + "/" + tmp.Project
+		depInfosMap[key] = append(depInfosMap[key], tmp.ConsumerDep)
+	}
+	for key, dependencies := range depInfosMap {
+		splitKey := strings.Split(key, "/")
+		domain, project := splitKey[0], splitKey[1]
+		putil.SetDomain(ctx, domain)
+		putil.SetProject(ctx, project)
+		err := sync.DoUpdateOpts(ctx, datasource.ResourceDependency, dependencies)
+		if err != nil {
+			log.Error("fail to create dep tasks", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func insertSyncAllKey(ctx context.Context) error {
+	_, err := dmongo.GetClient().GetDB().Collection(model.CollectionSync).InsertOne(ctx, bson.M{"key": SyncAllKey})
+	return err
 }


### PR DESCRIPTION
【issue】#1196
【修改内容】：
1、增加 syncAll 的 func
【修改原因】：
1、sc一开始没enableOnStart，且sc里面已经有数据了，后面我改配置enableOnStart为true，这些已有数据就没法同步了，需要提升可靠性
【影响范围】：无
【额外说明】：
需要sc启动时候：
1、判断enableStart是否true
2、如果true，查询sync-all key是否存在
3、如果不存在，执行sync all逻辑
4、sync all完成后，写sync-all key
【测试用例】：
1、enableOnStart开关未开启，不会做同步功能
2、enableOnStart开关开启，但是已经有SyncAllKey字段表示已经同步过，不需要再做同步了
3、enableOnstart开关开启，而且SyncAllKey字段不存在，需要做同步

创建两个个service，并且删除其创建过程的task
创建一个account，并且删除其创建过程的task
创建一个role，并且删除其创建过程的task
创建一个dep，并且删除其创建过程的task
执行SyncAll的操作，会创建，2个service，1个account，1个role，1个dep

删除所有资源