### PR TITLE
[bugfix] AddServiceVersionRule func should add sync task when sync is enabled

### DIFF
--- a/datasource/etcd/schema_test.go
+++ b/datasource/etcd/schema_test.go
@@ -113,7 +113,8 @@ func TestSyncSchema(t *testing.T) {
 			}
 			tasks, err := task.List(schemaContext(), &listTaskReq)
 			assert.NoError(t, err)
-			assert.Equal(t, 3, len(tasks))
+			// append the schemaID into service.Schemas if schemaID is new will create a kv task
+			assert.Equal(t, 4, len(tasks))
 			err = task.Delete(schemaContext(), tasks...)
 			assert.NoError(t, err)
 		})

--- a/datasource/etcd/sync_test.go
+++ b/datasource/etcd/sync_test.go
@@ -200,7 +200,8 @@ func TestSyncAll(t *testing.T) {
 			}
 			tasks, err := task.List(syncAllContext(), &listTaskReq)
 			assert.NoError(t, err)
-			assert.Equal(t, 3, len(tasks))
+			// append the schemaID into service.Schemas if schemaID is new will create a kv task
+			assert.Equal(t, 4, len(tasks))
 			err = task.Delete(syncAllContext(), tasks...)
 			assert.NoError(t, err)
 		})

--- a/server/service/rbac/rbac.go
+++ b/server/service/rbac/rbac.go
@@ -23,14 +23,16 @@ import (
 	"errors"
 	"io/ioutil"
 
-	"github.com/apache/servicecomb-service-center/pkg/log"
-	"github.com/apache/servicecomb-service-center/server/config"
-	"github.com/apache/servicecomb-service-center/server/plugin/security/cipher"
 	"github.com/go-chassis/cari/pkg/errsvc"
 	"github.com/go-chassis/cari/rbac"
 	"github.com/go-chassis/go-archaius"
 	"github.com/go-chassis/go-chassis/v2/security/authr"
 	"github.com/go-chassis/go-chassis/v2/security/secret"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/server/config"
+	"github.com/apache/servicecomb-service-center/server/plugin/security/cipher"
+	"github.com/apache/servicecomb-service-center/server/service/sync"
 )
 
 const (
@@ -131,7 +133,8 @@ func initFirstTime() {
 		Roles:    []string{rbac.RoleAdmin},
 		Password: pwd,
 	}
-	err := CreateAccount(context.Background(), a)
+	ctx := sync.SetContext(context.Background())
+	err := CreateAccount(ctx, a)
 	if err == nil {
 		log.Info("root account init success")
 		return


### PR DESCRIPTION
【issue】https://github.com/apache/servicecomb-service-center/issues/1196
【修改内容】：
1、通过排除 generate key 发现还是一部分 task 任务未同步，主要是 schema，service 更新，服务依赖dep-queue，已经初始化时 rbac 的 root 账号
【修改原因】： 
1、bug 修复，依赖关系同步后未发现服务之前的同步关系
2、初始化 root 未同步
【影响范围】：无
【额外说明】：无
【测试用例】：
1、由于修改了DeleteContent会多创建一个kv类型的task，schema-content，所以在schema测试用例和sync测试用例中，查询时从原先的3改成了4

