### PR TITLE
[fix] exchange account and role order in SynAll func

### DIFF
--- a/datasource/etcd/sync.go
+++ b/datasource/etcd/sync.go
@@ -76,11 +76,11 @@ func (s *SyncManager) SyncAll(ctx context.Context) error {
 			log.Error(fmt.Sprintf("fail to unlock the %s key", SyncAllLockKey), err)
 		}
 	}(lock)
-	err = syncAllAccounts(ctx)
+	err = syncAllRoles(ctx)
 	if err != nil {
 		return err
 	}
-	err = syncAllRoles(ctx)
+	err = syncAllAccounts(ctx)
 	if err != nil {
 		return err
 	}

--- a/server/service/rbac/rbac.go
+++ b/server/service/rbac/rbac.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	"github.com/apache/servicecomb-service-center/server/config"
 	"github.com/apache/servicecomb-service-center/server/plugin/security/cipher"
-	"github.com/apache/servicecomb-service-center/server/service/sync"
 )
 
 const (
@@ -133,8 +132,7 @@ func initFirstTime() {
 		Roles:    []string{rbac.RoleAdmin},
 		Password: pwd,
 	}
-	ctx := sync.SetContext(context.Background())
-	err := CreateAccount(ctx, a)
+	err := CreateAccount(context.Background(), a)
 	if err == nil {
 		log.Info("root account init success")
 		return


### PR DESCRIPTION
【issue】https://github.com/apache/servicecomb-service-center/issues/1196
【修改内容】：
1、修改account和role同步顺序
【修改原因】：
1、修改account和role同步顺序
【影响范围】：无
【额外说明】：无
【测试用例】：
无