### PR TITLE
[feat] add sc 2.1.0 releaseNotes

### DIFF
--- a/docs/release/Readme.md
+++ b/docs/release/Readme.md
@@ -2,6 +2,7 @@
 
 #### Release Notes
 
+- [Service-Center-2.1.0 Release Notes](releaseNotes-2.1.0.md)
 - [Service-Center-2.0.0 Release Notes](releaseNotes-2.0.0.md)
 - [Service-Center-1.1.0 Release Notes](releaseNotes-1.1.0.md)
 - [Service-Center-1.0.0 Release Notes](releaseNotes-1.0.0.md)

--- a/docs/release/releaseNotes-2.1.0.md
+++ b/docs/release/releaseNotes-2.1.0.md
@@ -1,0 +1,27 @@
+# Release Notes
+        Release Notes - Apache ServiceComb - Version service-center-2.1.0
+
+### Bug
+- [SCB-2400](https://issues.apache.org/jira/browse/SCB-2400) - Govern api return empty schemaIds
+- [SCB-2403](https://issues.apache.org/jira/browse/SCB-2403) - Start up failed when upgrade sc version
+- [SCB-2404](https://issues.apache.org/jira/browse/SCB-2404) - Return internal properties when list all microservices
+- [SCB-2411](https://issues.apache.org/jira/browse/SCB-2411) - Try dlock before start retirement job
+- [SCB-2418](https://issues.apache.org/jira/browse/SCB-2418) - Fix etcd metrics not correct
+- [SCB-2420](https://issues.apache.org/jira/browse/SCB-2420) - Can not delete unused role
+### New Feature
+- [SCB-2402](https://issues.apache.org/jira/browse/SCB-2402) - Support synchronization of multiple registries
+- [SCB-2401](https://issues.apache.org/jira/browse/SCB-2401) - Append inner properties when heartbeat success
+- [SCB-2408](https://issues.apache.org/jira/browse/SCB-2408) - Add put instance service
+- [SCB-2409](https://issues.apache.org/jira/browse/SCB-2409) - Add resource usage service
+- [SCB-2412](https://issues.apache.org/jira/browse/SCB-2412) - Add dlock service
+- [SCB-2414](https://issues.apache.org/jira/browse/SCB-2414) - Add schema retire cron job
+- [SCB-2415](https://issues.apache.org/jira/browse/SCB-2415) - Add schema ref
+- [SCB-2419](https://issues.apache.org/jira/browse/SCB-2419) - Add govern service
+### Improvement
+- [SCB-2405](https://issues.apache.org/jira/browse/SCB-2405) - Use dlock instead
+- [SCB-2406](https://issues.apache.org/jira/browse/SCB-2406) - Using cari's mongo db client
+- [SCB-2407](https://issues.apache.org/jira/browse/SCB-2407) - Using cari db client
+- [SCB-2410](https://issues.apache.org/jira/browse/SCB-2410) - Refactoring disco service
+- [SCB-2413](https://issues.apache.org/jira/browse/SCB-2413) - Refactoring RBAC datasource interface
+- [SCB-2416](https://issues.apache.org/jira/browse/SCB-2416) - Refactoring quota mgr
+- [SCB-2417](https://issues.apache.org/jira/browse/SCB-2417) - Refactoring schema service


### PR DESCRIPTION
【修改内容】：新增 sc 的 2.1.0 版本的releaseNotes
【修改原因】：发布2.1.0版本
【影响范围】：无
【额外说明】：无
【测试用例】：无需修改测试用例