### PR TITLE
[bug] move the time setting of the service to the disco layer

### DIFF
--- a/datasource/etcd/ms.go
+++ b/datasource/etcd/ms.go
@@ -82,8 +82,6 @@ func (ds *MetadataManager) RegisterService(ctx context.Context, request *pb.Crea
 		ctx = util.SetContext(ctx, uuid.ContextKey, index)
 		service.ServiceId = uuid.Generator().GetServiceID(ctx)
 	}
-	service.Timestamp = strconv.FormatInt(time.Now().Unix(), 10)
-	service.ModTimestamp = service.Timestamp
 
 	data, err := json.Marshal(service)
 	if err != nil {

--- a/datasource/mongo/ms.go
+++ b/datasource/mongo/ms.go
@@ -74,8 +74,6 @@ func (ds *MetadataManager) RegisterService(ctx context.Context, request *discove
 		ctx = util.SetContext(ctx, uuid.ContextKey, util.StringJoin([]string{domain, project, service.Environment, service.AppId, service.ServiceName, service.Alias, service.Version}, "/"))
 		service.ServiceId = uuid.Generator().GetServiceID(ctx)
 	}
-	service.Timestamp = strconv.FormatInt(time.Now().Unix(), 10)
-	service.ModTimestamp = service.Timestamp
 	// the service unique index in table is (serviceId/serviceEnv,serviceAppid,servicename,serviceVersion)
 	if len(service.Alias) != 0 {
 		serviceID, err := GetServiceID(ctx, &discovery.MicroServiceKey{

--- a/server/service/disco/metadata.go
+++ b/server/service/disco/metadata.go
@@ -20,6 +20,8 @@ package disco
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/pkg/log"
@@ -69,7 +71,15 @@ func registerService(ctx context.Context, request *pb.CreateServiceRequest) (*pb
 		return nil, quotaErr
 	}
 
+	assignDefaultValue(service)
+
 	return datasource.GetMetadataManager().RegisterService(ctx, request)
+}
+
+func assignDefaultValue(service *pb.MicroService) {
+	formatTenBase := 10
+	service.Timestamp = strconv.FormatInt(time.Now().Unix(), formatTenBase)
+	service.ModTimestamp = service.Timestamp
 }
 
 func registerServiceDetails(ctx context.Context, in *pb.CreateServiceRequest, serviceID string) (*pb.CreateServiceResponse, error) {


### PR DESCRIPTION
【修改内容】
1、将service的时间修改移动到resource层
【修改原因】
1、在同步中发先，同步过去的service会重新修改这个时间。当两个引擎正在通过，连续触发创建服务和删除服务的时候，会导致删除服务事件被抛弃，因为另外一个引擎在创建服务时会把之前原先的时间给修改了，导致事件呗抛弃
【测试用例】无需修改测试用例