### PR TITLE
[fix] modify schema url in frontend

### DIFF
--- a/.github/workflows/eventbase-ci.yml
+++ b/.github/workflows/eventbase-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out source code
         uses: actions/checkout@v1

--- a/.github/workflows/static_check.yml
+++ b/.github/workflows/static_check.yml
@@ -5,10 +5,10 @@ jobs:
     name: Merge check
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -18,10 +18,10 @@ jobs:
   ut4etcd:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -31,10 +31,10 @@ jobs:
   ut4mongo:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -46,10 +46,10 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.16
+      - name: Set up Go 1.17
         uses: actions/setup-go@v1
         with:
-          go-version: 1.16
+          go-version: 1.17
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/frontend/app/scripts/modules/serviceCenter/controllers/schemaCtrl.js
+++ b/frontend/app/scripts/modules/serviceCenter/controllers/schemaCtrl.js
@@ -16,8 +16,8 @@
  */
 'use strict';
 angular.module('serviceCenter.sc')
-    .controller('schemaController', ['$scope', 'apiConstant', 'httpService', '$stateParams', 'servicesList', '$q', '$mdDialog', 'YAML', '$http', '$state', '$document', '$interval',
-        function($scope, apiConstant, httpService, $stateParams, servicesList, $q, $mdDialog, YAML, $http, $state, $document, $interval) {
+    .controller('schemaController', ['$scope', 'apiConstant', 'httpService', '$stateParams', 'servicesInfo', '$q', '$mdDialog', 'YAML', '$http', '$state', '$document', '$interval',
+        function($scope, apiConstant, httpService, $stateParams, servicesInfo, $q, $mdDialog, YAML, $http, $state, $document, $interval) {
 
             var serviceId = $stateParams.serviceId;
             $scope.schemaName = [];
@@ -26,13 +26,9 @@ angular.module('serviceCenter.sc')
             var addresses = [];
             var instances = [];
             var promises = [];
-            if (servicesList && servicesList.data && servicesList.data.allServicesDetail) {
-                servicesList.data.allServicesDetail.forEach(function(serviceDetail) {
-                    var service = serviceDetail.microService;
-                    if (service.serviceId == serviceId) {
-                        $scope.schemaName = service.schemas || [];
-                    }
-                });
+            if (servicesInfo && servicesInfo.data && servicesInfo.data.service) {
+                var service = servicesInfo.data.service;
+                $scope.schemaName = service.schemas || [];
             }
 
             $scope.downloadAllSchema = function() {

--- a/frontend/app/scripts/modules/serviceCenter/controllers/serviceInfoCtrl.js
+++ b/frontend/app/scripts/modules/serviceCenter/controllers/serviceInfoCtrl.js
@@ -20,22 +20,17 @@ angular.module('serviceCenter.sc')
 	 '$stateParams','serviceInfo' ,function($scope, httpService, commonService, $q, apiConstant, $state, $stateParams, serviceInfo){
 
 			var serviceId = $stateParams.serviceId;
-			if(serviceInfo && serviceInfo.data && serviceInfo.data.allServicesDetail){
-				serviceInfo.data.allServicesDetail.forEach(function(serviceDetail){
-					var service = serviceDetail.microService;
-	                if(service.serviceId == serviceId){
-	                    $scope.serviceDetail = {
-	                        serviceName: service.serviceName,
-	                        status: service.status,
-	                        appId: service.appId,
-	                        version: service.version,
-	                        createdAt: commonService.timeFormat(service.timestamp),
-	                        serviceId: service.serviceId
-	                    };
-	                }
-            	});
+			if(serviceInfo && serviceInfo.data && serviceInfo.data.service){
+				var service = serviceInfo.data.service;
+				$scope.serviceDetail = {
+					serviceName: service.serviceName,
+					status: service.status,
+					appId: service.appId,
+					version: service.version,
+					createdAt: commonService.timeFormat(service.timestamp),
+					serviceId: service.serviceId
+				};
 			}
-			
 
 			var apis = [];
 			var instanceUrl = apiConstant.api.instances.url;

--- a/frontend/app/scripts/scRouterConfig.js
+++ b/frontend/app/scripts/scRouterConfig.js
@@ -57,15 +57,11 @@ angular.module('serviceCenter.router', [])
                         $(".loader").show();
                         var serviceId = $stateParams.serviceId;
                         var deferred = $q.defer();
-                        var url = apiConstant.api.allServices.url;
-                        var method = apiConstant.api.allServices.method;
+                        var url = apiConstant.api.particularService.url.replace('{{serviceId}}', serviceId);
+                        var method = apiConstant.api.particularService.method;
                         httpService.apiRequest(url, method, null, null, null).then(function(response) {
                             $(".loader").hide();
-                            if (response && response.data && response.data.allServicesDetail) {
-                                deferred.resolve(response);
-                            } else {
-                                deferred.resolve(response);
-                            }
+                            deferred.resolve(response);
                         }, function(error) {
                             $(".loader").hide();
                             deferred.reject(error);
@@ -116,18 +112,15 @@ angular.module('serviceCenter.router', [])
                     }
                 },
                 resolve: {
-                    servicesList: ['$q', 'httpService', 'apiConstant', function($q, httpService, apiConstant) {
+                    servicesInfo: ['$q', 'httpService', 'apiConstant', '$stateParams', function($q, httpService,  apiConstant, $stateParams) {
                         $(".loader").show();
                         var deferred = $q.defer();
-                        var url = apiConstant.api.allServices.url;
-                        var method = apiConstant.api.allServices.method;
+                        var serviceId = $stateParams.serviceId;
+                        var url = apiConstant.api.particularService.url.replace('{{serviceId}}', serviceId);
+                        var method = apiConstant.api.particularService.method;
                         httpService.apiRequest(url, method, null, null, null).then(function(response) {
                             $(".loader").hide();
-                            if (response && response.data && response.data.allServicesDetail) {
-                                deferred.resolve(response);
-                            } else {
-                                deferred.resolve(response);
-                            }
+                            deferred.resolve(response);
                         }, function(error) {
                             $(".loader").hide();
                             deferred.reject(error);


### PR DESCRIPTION
【问题】前端页面当点击详细服务时，改服务的schema没办法展示，因为新版本list接口返回的微服务是没有schema信息的，所以要换成用service详情接口来查
【修改内容】修改相关的 js，接口调用方式由原先的查询所以，改成查询指定 id 的service
【测试用例】无需修改

![image](https://user-images.githubusercontent.com/27326092/158069300-e8cb2d6c-9a38-45b8-8ac4-61addd4c5a56.png)
