### PR TITLE
[fix] add enableOnStart conditional judgment in syncer health init

### DIFF
--- a/syncer/service/admin/health.go
+++ b/syncer/service/admin/health.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/apache/servicecomb-service-center/client"
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	pkgrpc "github.com/apache/servicecomb-service-center/pkg/rpc"
@@ -30,7 +32,6 @@ import (
 	"github.com/apache/servicecomb-service-center/syncer/config"
 	"github.com/apache/servicecomb-service-center/syncer/metrics"
 	"github.com/apache/servicecomb-service-center/syncer/rpc"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -62,8 +63,16 @@ type Peer struct {
 
 func init() {
 	cfg := config.GetConfig()
-	if cfg.Sync == nil || len(cfg.Sync.Peers) <= 0 {
+	if cfg.Sync == nil {
 		log.Warn("sync config is empty")
+		return
+	}
+	if !cfg.Sync.EnableOnStart {
+		log.Info("syncer is disabled")
+		return
+	}
+	if len(cfg.Sync.Peers) <= 0 {
+		log.Warn("peers parameter configuration is empty")
 		return
 	}
 	peerInfos = make([]*PeerInfo, 0, len(cfg.Sync.Peers))
@@ -83,6 +92,7 @@ func init() {
 		}
 	}
 }
+
 func Health() (*Resp, error) {
 	if len(peerInfos) <= 0 {
 		return nil, ErrConfigIsEmpty


### PR DESCRIPTION
【修改内容】增加 syncer 中的 health 初始化时对enableOnStart字段判断
【修改原因】若未开启同步，health连接clint会不断尝试grpc连接打印相关日志
【测试用例】无需修改
