### PR TITLE
[fix] userGuide.title link

### DIFF
--- a/frontend/app/scripts/modules/dashboard/views/dashboard.html
+++ b/frontend/app/scripts/modules/dashboard/views/dashboard.html
@@ -133,13 +133,13 @@ limitations under the License..
         <div class="panel-heading fw-600"><span class="text-center block">{{ "userGuide.title" | translate }}</span></div>
         <div class="panel-body">
             <ul class="userGuide-list">
-                <li><a target="_blank" href="http://servicecomb.apache.org/docs/quick-start/">ServiceComb QuickStart</a></li>
+                <li><a target="_blank" href="https://servicecomb.apache.org/docs/getting-started/">ServiceComb QuickStart</a></li>
                 <li><a target="_blank" href="http://servicecomb.apache.org/release/">ServiceComb Download links</a></li>
                 <li><a target="_blank" href="http://servicecomb.apache.org/year-archive/">ServiceComb Blogs</a></li>
-                <li><a target="_blank" href="http://servicecomb.apache.org/users/service-definition/">What is Service Definition?</a></li>
-                <li><a target="_blank" href="http://servicecomb.apache.org/users/service-contract/">What is Service Contract?</a></li>
-                <li><a target="_blank" href="http://servicecomb.apache.org/users/develop-with-springmvc/">Develop Applications using SpringMVC</a></li>
-                <li><a target="_blank" href="http://servicecomb.apache.org/docs/quick-start-dataconsistency/">Transaction Management</a></li>
+                <li><a target="_blank" href="https://servicecomb.apache.org/references/java-chassis/en_US/build-provider/definition/service-definition/">What is Service Definition?</a></li>
+                <li><a target="_blank" href="https://servicecomb.apache.org/references/java-chassis/en_US/build-provider/define-contract/">What is Service Contract?</a></li>
+                <li><a target="_blank" href="https://servicecomb.apache.org/references/java-chassis/en_US/build-provider/springmvc/">Develop Applications using SpringMVC</a></li>
+                <li><a target="_blank" href="https://github.com/apache/servicecomb-pack/blob/master/docs/user_guide.md">Transaction Management</a></li>
                 <li><a target="_blank" href="https://github.com/apache?q=servicecomb">Fork us on Github</a></li>
             </ul>
         </div>


### PR DESCRIPTION
【修改文件】前端页面一些链接
【修改原因】链接失效了
【测试用例】无需修改