### PR TITLE
[fix] Replace metadata URL to show more information

### DIFF
--- a/frontend/app/apiList/apiList.js
+++ b/frontend/app/apiList/apiList.js
@@ -39,6 +39,10 @@ angular.module('serviceCenter')
                 url: 'v4/default/registry/microservices/{{serviceId}}/schemas/{{schemaId}}',
                 method: 'GET'
             },
+            specifiedService: {
+              url: 'v4/default/govern/microservices/{{serviceId}}?options=instances',
+              method: 'GET'
+            },
             allServices: {
                 url: 'v4/default/govern/microservices?options=instances,dependencies&withShared=true',
                 method: 'GET'

--- a/frontend/app/scripts/modules/serviceCenter/controllers/serviceInfoCtrl.js
+++ b/frontend/app/scripts/modules/serviceCenter/controllers/serviceInfoCtrl.js
@@ -42,9 +42,9 @@ angular.module('serviceCenter.sc')
 			var providerUrl = apiConstant.api.provider.url;
 			var providerApi = providerUrl.replace('{{providerId}}', serviceId);
 			apis.push(providerApi);
-			var serviceUrl = apiConstant.api.particularService.url;
-			var particularServiceAPI = serviceUrl.replace('{{serviceId}}', serviceId);
-			apis.push(particularServiceAPI)
+			var serviceUrl = apiConstant.api.specifiedService.url;
+			var specifiedServiceAPI = serviceUrl.replace('{{serviceId}}', serviceId);
+			apis.push(specifiedServiceAPI)
 
 			var promises =[];
 			for (var i = 0; i < apis.length; i++) {


### PR DESCRIPTION
【背景】前端页面展示的元数据信息只包含了服务的信息，LocalCSE这边展示的数据包含所有实例以及schemas
【修改内容】
新增接口`v4/default/govern/microservices/{{serviceId}}?options=instances`
【验证】
<img width="546" alt="image" src="https://user-images.githubusercontent.com/27326092/165532071-708ab293-d092-4330-a114-9fe74411d70e.png">

