### PR TITLE
refactor policy validator

### DIFF
--- a/datasource/mongo/ms_test.go
+++ b/datasource/mongo/ms_test.go
@@ -138,4 +138,3 @@ func TestSyncMicroService(t *testing.T) {
 		})
 	})
 }
-

--- a/examples/service_center/request/register_intance_json.sh
+++ b/examples/service_center/request/register_intance_json.sh
@@ -27,8 +27,9 @@ Postman-Token: bf33f47f-acfe-76fe-8c53-d1f79a46b246
 	"instance": 
 	{
 	    "endpoints": [
-			"ase://127.0.0.1:99841"
+			"grpc://127.0.0.1:99841"
 		],
+		"virtualAddress": "xxx.xxx.xxx.local:8080"
 		"hostName":"ase",
 		"status":"UP",
 		"environment":"production",

--- a/go.sum
+++ b/go.sum
@@ -264,6 +264,7 @@ github.com/go-chassis/cari v0.0.0-20201210041921-7b6fbef2df11/go.mod h1:MgtsEI0A
 github.com/go-chassis/cari v0.4.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.0/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
 github.com/go-chassis/cari v0.5.1-0.20210823023004-74041d1363c4/go.mod h1:av/19fqwEP4eOC8unL/z67AAbFDwXUCko6SKa4Avrd8=
+github.com/go-chassis/cari v0.5.1-0.20220216075429-46c79de3311f/go.mod h1:tKTzguHTGohMCgkcWNZWtA4TwfcsJrIXpfYxsQtb7uw=
 github.com/go-chassis/cari v0.6.0 h1:cwBchwt9L8JOyO6QkzXFAsseMJ10zVSiVK8eDLD0HkA=
 github.com/go-chassis/cari v0.6.0/go.mod h1:mSDRCOQXGmlD69A6NG0hsv0UP1xbVPtL6HCGI6X1tqs=
 github.com/go-chassis/foundation v0.2.2-0.20201210043510-9f6d3de40234/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27pNeYaiE3ZxOBA=
@@ -272,16 +273,20 @@ github.com/go-chassis/foundation v0.3.0/go.mod h1:2PjwqpVwYEVaAldl5A58a08viH8p27
 github.com/go-chassis/foundation v0.4.0 h1:z0xETnSxF+vRXWjoIhOdzt6rywjZ4sB++utEl4YgWEY=
 github.com/go-chassis/foundation v0.4.0/go.mod h1:6NsIUaHghTFRGfCBcZN011zl196F6OR5QvD9N+P4oWU=
 github.com/go-chassis/go-archaius v1.5.1/go.mod h1:QPwvvtBxvwiC48rmydoAqxopqOr93RCQ6syWsIkXPXQ=
+github.com/go-chassis/go-archaius v1.5.2-0.20210301074935-e4694f6b077b/go.mod h1:qjfG7opNF/QTzj7SyVIn/eIawaPhl7xeGgg8kxzFsDw=
 github.com/go-chassis/go-archaius v1.5.6 h1:MF/yE9Mj51slccW6EmZInjFCmyfuhltRz9eu5Na4i88=
 github.com/go-chassis/go-archaius v1.5.6/go.mod h1:WsqeDyZsCR2qGdWEAEpywS1taxCUHRF4hPSHVMfnAkc=
 github.com/go-chassis/go-chassis-extension/protocol/grpc v0.0.0-20220208081606-003611df45da h1:DoPFX1Fy3MLEb1RvgchInKspm8DkxQhrvZ5kOcjeZAs=
 github.com/go-chassis/go-chassis-extension/protocol/grpc v0.0.0-20220208081606-003611df45da/go.mod h1:btid7R4NKuET4BCUkR74CL5EP0hk3J0jXSByjzwd9JM=
 github.com/go-chassis/go-chassis/v2 v2.3.0/go.mod h1:iyJ2DWSkqfnCmad/0Il9nXWHaob7RcwPGlIDRNxccH0=
+github.com/go-chassis/go-chassis/v2 v2.3.1-0.20211217084436-360a6a6a0ef3/go.mod h1:oMnRaz2P+OPTtEfh2HEuiF9YzdYHQrNVPXdnbKzKO9w=
 github.com/go-chassis/go-chassis/v2 v2.4.0 h1:BMmOS2zM/E8KDUoCNpSqalhFsW9fRjwh2Pz5wk1EGC8=
 github.com/go-chassis/go-chassis/v2 v2.4.0/go.mod h1:oMnRaz2P+OPTtEfh2HEuiF9YzdYHQrNVPXdnbKzKO9w=
 github.com/go-chassis/go-restful-swagger20 v1.0.3 h1:kWfeLwMwJZVkXP1zNyFpkmR41UZ55UTcOptTteXhvEs=
 github.com/go-chassis/go-restful-swagger20 v1.0.3/go.mod h1:eW62fYuzlNFDvIacB6AV8bhUDCTy4myfTCv0bT9Gbb0=
 github.com/go-chassis/kie-client v0.0.0-20201210060018-938c7680a9ab/go.mod h1:UTdbtyN5ge/v9DmQzdVRxQP7z51Q4z6hyl+W6ZpUHFM=
+github.com/go-chassis/kie-client v0.1.0/go.mod h1:UTdbtyN5ge/v9DmQzdVRxQP7z51Q4z6hyl+W6ZpUHFM=
+github.com/go-chassis/kie-client v0.1.1-0.20210926011742-97eed4281056/go.mod h1:N4SrGTb+e9ZiuOOU9vC/AohqsDtCkY2amNAPcvpEem0=
 github.com/go-chassis/kie-client v0.2.0 h1:9/BXLu8HaH9b7WLIrtizfhtbBaQEZlsbsk9c8z+mhgc=
 github.com/go-chassis/kie-client v0.2.0/go.mod h1:JCyQeOZcr3ti79tc8tix0VzkC2YpB5j7PRbsOmQGcKQ=
 github.com/go-chassis/openlog v1.1.2/go.mod h1:+eYCADVxWyJkwsFMUBrMxyQlNqW+UUsCxvR2LrYZUaA=
@@ -620,6 +625,7 @@ github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kN
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
@@ -932,6 +938,8 @@ go.etcd.io/etcd/raft/v3 v3.5.4/go.mod h1:SCuunjYvZFC0fBX0vxMSPjuZmpcSk+XaAcMrD6D
 go.etcd.io/etcd/server/v3 v3.5.0/go.mod h1:3Ah5ruV+M+7RZr0+Y/5mNLwC+eQlni+mQmOVdCRJoS4=
 go.etcd.io/etcd/server/v3 v3.5.4 h1:CMAZd0g8Bn5NRhynW6pKhc4FRg41/0QYy3d7aNm9874=
 go.etcd.io/etcd/server/v3 v3.5.4/go.mod h1:S5/YTU15KxymM5l3T6b09sNOHPXqGYIZStpuuGbb65c=
+go.mongodb.org/mongo-driver v1.4.2/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
+go.mongodb.org/mongo-driver v1.4.6/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4SoGjYphSc=
 go.mongodb.org/mongo-driver v1.5.1 h1:9nOVLGDfOaZ9R0tBumx/BcuqkbFpyTCU2r/Po7A2azI=
 go.mongodb.org/mongo-driver v1.5.1/go.mod h1:gRXCHX4Jo7J0IJ1oDQyUxF7jfy19UfxniMS4xxMmUqw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
@@ -992,6 +1000,7 @@ golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -1001,6 +1010,7 @@ golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=

--- a/server/bootstrap/bootstrap.go
+++ b/server/bootstrap/bootstrap.go
@@ -60,7 +60,8 @@ import (
 	_ "github.com/apache/servicecomb-service-center/server/rest/admin"
 
 	//governance
-	_ "github.com/apache/servicecomb-service-center/server/service/gov/kie"
+	_ "github.com/apache/servicecomb-service-center/server/ext/policy"
+	_ "github.com/apache/servicecomb-service-center/server/service/grc/kie"
 
 	//metrics
 	_ "github.com/apache/servicecomb-service-center/server/rest/metrics"

--- a/server/ext/policy/buitin.go
+++ b/server/ext/policy/buitin.go
@@ -1,0 +1,51 @@
+package policy
+
+import (
+	"github.com/apache/servicecomb-service-center/server/service/grc"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+func init() {
+	grc.RegisterPolicySchema("loadbalancer", &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type:     []string{"object"},
+			Required: []string{"rule"},
+			Properties: map[string]spec.Schema{
+				"rule": {
+					SchemaProps: spec.SchemaProps{Type: []string{"string"}}},
+			},
+		}})
+	grc.RegisterPolicySchema("circuitBreaker", &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"minimumNumberOfCalls": {
+					SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+			},
+		}})
+	grc.RegisterPolicySchema("instanceIsolation", &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"minimumNumberOfCalls": {
+					SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+			},
+		}})
+	grc.RegisterPolicySchema("faultInjection", &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"percentage": {
+					SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+			},
+		}})
+	grc.RegisterPolicySchema("bulkhead", &spec.Schema{
+		SchemaProps: spec.SchemaProps{
+			Type: []string{"object"},
+			Properties: map[string]spec.Schema{
+				"maxConcurrentCalls": {
+					SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
+			},
+		}})
+
+}

--- a/server/resource/gov/gov_resource.go
+++ b/server/resource/gov/gov_resource.go
@@ -26,8 +26,7 @@ import (
 	model "github.com/apache/servicecomb-service-center/pkg/gov"
 	"github.com/apache/servicecomb-service-center/pkg/log"
 	"github.com/apache/servicecomb-service-center/pkg/rest"
-	"github.com/apache/servicecomb-service-center/server/service/gov"
-	"github.com/apache/servicecomb-service-center/server/service/gov/kie"
+	"github.com/apache/servicecomb-service-center/server/service/grc"
 	"github.com/go-chassis/cari/discovery"
 )
 
@@ -63,15 +62,15 @@ func (t *Governance) Create(w http.ResponseWriter, r *http.Request) {
 		rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 		return
 	}
-	err = gov.ValidateSpec(kind, p.Spec)
+	err = grc.ValidatePolicySpec(kind, p.Spec)
 	if err != nil {
-		log.Error("validate policy err", err)
+		log.Error(fmt.Sprintf("validate policy [%s] err", kind), err)
 		rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 		return
 	}
-	id, err := gov.Create(r.Context(), kind, project, p)
+	id, err := grc.Create(r.Context(), kind, project, p)
 	if err != nil {
-		if _, ok := err.(*kie.ErrIllegalItem); ok {
+		if _, ok := err.(*grc.ErrIllegalItem); ok {
 			log.Error("", err)
 			rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 			return
@@ -101,16 +100,16 @@ func (t *Governance) Put(w http.ResponseWriter, r *http.Request) {
 		rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 		return
 	}
-	err = gov.ValidateSpec(kind, p.Spec)
+	err = grc.ValidatePolicySpec(kind, p.Spec)
 	if err != nil {
 		log.Error("validate policy err", err)
 		rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 		return
 	}
 	log.Info(fmt.Sprintf("update %v", &p))
-	err = gov.Update(r.Context(), kind, id, project, p)
+	err = grc.Update(r.Context(), kind, id, project, p)
 	if err != nil {
-		if _, ok := err.(*kie.ErrIllegalItem); ok {
+		if _, ok := err.(*grc.ErrIllegalItem); ok {
 			log.Error("", err)
 			rest.WriteError(w, discovery.ErrInvalidParams, err.Error())
 			return
@@ -131,9 +130,9 @@ func (t *Governance) ListOrDisPlay(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	var err error
 	if kind == DisplayKey {
-		body, err = gov.Display(r.Context(), project, app, environment)
+		body, err = grc.Display(r.Context(), project, app, environment)
 	} else {
-		body, err = gov.List(r.Context(), kind, project, app, environment)
+		body, err = grc.List(r.Context(), kind, project, app, environment)
 	}
 	if err != nil {
 		processError(w, err, "list gov err")
@@ -148,7 +147,7 @@ func (t *Governance) Get(w http.ResponseWriter, r *http.Request) {
 	kind := query.Get(KindKey)
 	id := query.Get(IDKey)
 	project := query.Get(ProjectKey)
-	body, err := gov.Get(r.Context(), kind, id, project)
+	body, err := grc.Get(r.Context(), kind, id, project)
 	if err != nil {
 		processError(w, err, "get gov err")
 		return
@@ -162,7 +161,7 @@ func (t *Governance) Delete(w http.ResponseWriter, r *http.Request) {
 	kind := query.Get(KindKey)
 	id := query.Get(IDKey)
 	project := query.Get(ProjectKey)
-	err := gov.Delete(r.Context(), kind, id, project)
+	err := grc.Delete(r.Context(), kind, id, project)
 	if err != nil {
 		processError(w, err, "delete gov err")
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ import (
 	"github.com/apache/servicecomb-service-center/server/config"
 	"github.com/apache/servicecomb-service-center/server/event"
 	"github.com/apache/servicecomb-service-center/server/plugin/security/tlsconf"
-	"github.com/apache/servicecomb-service-center/server/service/gov"
+	"github.com/apache/servicecomb-service-center/server/service/grc"
 	"github.com/apache/servicecomb-service-center/server/service/rbac"
 	"github.com/go-chassis/foundation/gopool"
 )
@@ -163,7 +163,7 @@ func (s *ServiceCenterServer) startServices() {
 	// load server plugins
 	plugin.LoadPlugins()
 	rbac.Init()
-	if err := gov.Init(); err != nil {
+	if err := grc.Init(); err != nil {
 		log.Fatal("init gov failed", err)
 	}
 	// check version

--- a/server/service/grc/config_distributor.go
+++ b/server/service/grc/config_distributor.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package gov
+package grc
 
 import (
 	"context"

--- a/server/service/grc/config_distributor_test.go
+++ b/server/service/grc/config_distributor_test.go
@@ -15,18 +15,19 @@
  * limitations under the License.
  */
 
-package gov_test
+package grc_test
 
 import (
 	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/apache/servicecomb-service-center/pkg/gov"
 	"github.com/apache/servicecomb-service-center/server/config"
-	svc "github.com/apache/servicecomb-service-center/server/service/gov"
-	_ "github.com/apache/servicecomb-service-center/server/service/gov/mock"
-	"github.com/stretchr/testify/assert"
+	grcsvc "github.com/apache/servicecomb-service-center/server/service/grc"
+	_ "github.com/apache/servicecomb-service-center/server/service/grc/mock"
 )
 
 const Project = "default"
@@ -47,14 +48,14 @@ func init() {
 			},
 		},
 	}
-	err := svc.Init()
+	err := grcsvc.Init()
 	if err != nil {
 		panic(err)
 	}
 }
 
 func TestCreate(t *testing.T) {
-	res, err := svc.Create(context.TODO(), MockKind, Project, &gov.Policy{
+	res, err := grcsvc.Create(context.TODO(), MockKind, Project, &gov.Policy{
 		GovernancePolicy: &gov.GovernancePolicy{
 			Name: "Traffic2adminAPI",
 			Selector: gov.Selector{
@@ -70,7 +71,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestUpdate(t *testing.T) {
-	err := svc.Update(context.TODO(), MockKind, id, Project, &gov.Policy{
+	err := grcsvc.Update(context.TODO(), MockKind, id, Project, &gov.Policy{
 		GovernancePolicy: &gov.GovernancePolicy{
 			Name: "Traffic2adminAPI",
 			Selector: gov.Selector{
@@ -84,7 +85,7 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDisplay(t *testing.T) {
-	res, err := svc.Create(context.TODO(), MatchGroup, Project, &gov.Policy{
+	res, err := grcsvc.Create(context.TODO(), MatchGroup, Project, &gov.Policy{
 		GovernancePolicy: &gov.GovernancePolicy{
 			Name: "Traffic2adminAPI",
 			Selector: gov.Selector{
@@ -96,7 +97,7 @@ func TestDisplay(t *testing.T) {
 	id = string(res)
 	assert.NoError(t, err)
 	policies := &[]*gov.DisplayData{}
-	res, err = svc.Display(context.TODO(), Project, MockApp, MockEnv)
+	res, err = grcsvc.Display(context.TODO(), Project, MockApp, MockEnv)
 	assert.NoError(t, err)
 	err = json.Unmarshal(res, policies)
 	assert.NoError(t, err)
@@ -105,7 +106,7 @@ func TestDisplay(t *testing.T) {
 
 func TestList(t *testing.T) {
 	policies := &[]*gov.Policy{}
-	res, err := svc.List(context.TODO(), MockKind, Project, MockApp, MockEnv)
+	res, err := grcsvc.List(context.TODO(), MockKind, Project, MockApp, MockEnv)
 	assert.NoError(t, err)
 	err = json.Unmarshal(res, policies)
 	assert.NoError(t, err)
@@ -114,7 +115,7 @@ func TestList(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	policy := &gov.Policy{}
-	res, err := svc.Get(context.TODO(), MockKind, id, Project)
+	res, err := grcsvc.Get(context.TODO(), MockKind, id, Project)
 	assert.NoError(t, err)
 	err = json.Unmarshal(res, policy)
 	assert.NoError(t, err)
@@ -122,8 +123,8 @@ func TestGet(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	err := svc.Delete(context.TODO(), MockKind, id, Project)
+	err := grcsvc.Delete(context.TODO(), MockKind, id, Project)
 	assert.NoError(t, err)
-	res, _ := svc.Get(context.TODO(), MockKind, id, Project)
+	res, _ := grcsvc.Get(context.TODO(), MockKind, id, Project)
 	assert.Nil(t, res)
 }

--- a/server/service/grc/mock/mock.go
+++ b/server/service/grc/mock/mock.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/apache/servicecomb-service-center/pkg/gov"
 	"github.com/apache/servicecomb-service-center/server/config"
-	svc "github.com/apache/servicecomb-service-center/server/service/gov"
+	grcsvc "github.com/apache/servicecomb-service-center/server/service/grc"
 )
 
 type Distributor struct {
@@ -126,14 +126,14 @@ func (d *Distributor) Get(ctx context.Context, kind, id, project string) ([]byte
 }
 
 func (d *Distributor) Type() string {
-	return svc.ConfigDistributorMock
+	return grcsvc.ConfigDistributorMock
 }
 func (d *Distributor) Name() string {
 	return d.name
 }
-func new(opts config.DistributorOptions) (svc.ConfigDistributor, error) {
+func new(opts config.DistributorOptions) (grcsvc.ConfigDistributor, error) {
 	return &Distributor{name: opts.Name, lbPolicies: map[string]*gov.Policy{}}, nil
 }
 func init() {
-	svc.InstallDistributor(svc.ConfigDistributorMock, new)
+	grcsvc.InstallDistributor(grcsvc.ConfigDistributorMock, new)
 }

--- a/server/service/grc/policy_test.go
+++ b/server/service/grc/policy_test.go
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-package gov_test
+package grc_test
 
 import (
+	"github.com/apache/servicecomb-service-center/server/service/grc"
 	"testing"
 
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
-	"github.com/apache/servicecomb-service-center/server/service/gov"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,9 +45,9 @@ func TestPolicySchema_Validate(t *testing.T) {
 						SchemaProps: spec.SchemaProps{Type: []string{"integer"}}},
 				},
 			}}
-		gov.RegisterPolicy("custom", schema)
+		grc.RegisterPolicySchema("custom", schema)
 		t.Run("given right content, should no error", func(t *testing.T) {
-			err := gov.ValidateSpec("custom", map[string]interface{}{
+			err := grc.ValidatePolicySpec("custom", map[string]interface{}{
 				"allow":   true,
 				"timeout": "5s",
 				"name":    "a",
@@ -58,7 +58,7 @@ func TestPolicySchema_Validate(t *testing.T) {
 			assert.NoError(t, err)
 		})
 		t.Run("given value with wrong type, should return error", func(t *testing.T) {
-			err := gov.ValidateSpec("custom", map[string]interface{}{
+			err := grc.ValidatePolicySpec("custom", map[string]interface{}{
 				"allow":   "str",
 				"timeout": "5s",
 				"name":    "a",
@@ -69,7 +69,7 @@ func TestPolicySchema_Validate(t *testing.T) {
 			assert.Error(t, err)
 		})
 		t.Run("do not give required value, should return error", func(t *testing.T) {
-			err := gov.ValidateSpec("custom", map[string]interface{}{
+			err := grc.ValidatePolicySpec("custom", map[string]interface{}{
 				"allow":   true,
 				"timeout": "5s",
 				"age":     10,

--- a/server/service/grc/validate.go
+++ b/server/service/grc/validate.go
@@ -15,14 +15,26 @@
  * limitations under the License.
  */
 
-package kie
+package grc
 
 import (
 	"fmt"
 )
 
-type Validator struct {
-}
+const (
+	KeyPrefix       = "servicecomb."
+	KindMatchGroup  = "match-group"
+	GroupNamePrefix = "scene-"
+	StatusEnabled   = "enabled"
+	TypeText        = "text"
+	KeyApp          = "app"
+	KeyEnvironment  = "environment"
+	EnvAll          = "all"
+	Alias           = "alias"
+	Method          = "method"
+	Matches         = "matches"
+	Rules           = "rules"
+)
 
 type ErrIllegalItem struct {
 	err string
@@ -37,7 +49,11 @@ func (e *ErrIllegalItem) Error() string {
 	return fmt.Sprintf("illegal item : %v , msg: %s", e.val, e.err)
 }
 
-func (d *Validator) Validate(kind string, spec interface{}) error {
+// Validate is a legacy API, it is not extensible due to its bad design pattern
+// Please use grc.RegisterPolicySchema
+// it only response for validate 3 kinds of policy. if it is not this 3 kinds, it will not return error,
+// it return nil error, and let grc.ValidatePolicySpec to do the job
+func Validate(kind string, spec interface{}) error {
 	switch kind {
 	case "match-group":
 		return matchValidate(spec)
@@ -45,16 +61,9 @@ func (d *Validator) Validate(kind string, spec interface{}) error {
 		return retryValidate(spec)
 	case "rate-limiting":
 		return rateLimitingValidate(spec)
-	case "circuit-breaker":
-	case "instance-isolation":
-	case "fault-injection":
-	case "bulkhead":
-	case "loadbalancer":
-		return nil
 	default:
-		return &ErrIllegalItem{"not support kind yet", kind}
+		return nil
 	}
-	return nil
 }
 
 func matchValidate(val interface{}) error {


### PR DESCRIPTION
**动机：**
- 扩展新的策略开始变得丑陋，对开发者不友好 https://github.com/apache/servicecomb-service-center/pull/1319 https://github.com/apache/servicecomb-service-center/pull/1318
- 如此扩展对构建一个生态没有帮助

**方案：**
之前已经提供了全新的validate机制，但是还没有跟整套方案无缝衔接https://github.com/apache/servicecomb-service-center/pull/1097
本次重构将新老validate机制合一并保持向前兼容