### PR TITLE
Change: always authenticate the request with HTTP Header 'Authorization'

### DIFF
--- a/etc/conf/app.yaml
+++ b/etc/conf/app.yaml
@@ -169,7 +169,10 @@ rbac:
   publicKeyFile: ./public.key
   releaseLockAfter: 15m # failure login attempt causes account blocking, that is block duration
   retainLockHistoryFor: 20m # the ttl of lock history
-  scope: '*' # specify auth resource scope, can be account,role,service,service/schema,...
+  # specify auth resource scope, can be account,role,service,service/schema,...
+  # The authenticator skip the authentication of the request, if the resource type of the request is not specified in the scope
+  # The authenticator always authenticate the request with the HTTP Header 'Authorization'.
+  scope: '*'
 
 metrics:
   # enable to start metrics gather


### PR DESCRIPTION
背景：当前如果在开启身份认证的情况下，可以支持通过scope来控制资源的鉴权范围。但当前的实现把身份认证的阶段也同时跳过了。即传递一个无效的Authorization也会跳过认证阶段，可返回请求的资源。存在API的歧义，应该修改成允许不传Authorization头，但如果传，必须校验其合法性。

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `go build` `go test` `go fmt` `go vet` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
 - [ ] Never comment source code, delete it.
 - [ ] UT should has "context, subject, expected result" result as test case name, when you call t.Run().
---
