### PR TITLE
bugfix: return 'no permission' when discover provider in specify env

### DIFF
--- a/server/plugin/auth/buildin/parser_test.go
+++ b/server/plugin/auth/buildin/parser_test.go
@@ -18,18 +18,18 @@
 package buildin_test
 
 import (
-	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
-	_ "github.com/apache/servicecomb-service-center/test"
-
 	"context"
 	"net/http"
 	"strings"
 	"testing"
 
+	_ "github.com/apache/servicecomb-service-center/test"
+
 	"github.com/apache/servicecomb-service-center/pkg/rest"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth"
 	"github.com/apache/servicecomb-service-center/server/plugin/auth/buildin"
+	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
 	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
 	"github.com/go-chassis/cari/discovery"
 	"github.com/stretchr/testify/assert"

--- a/server/plugin/auth/buildin/service_parser_test.go
+++ b/server/plugin/auth/buildin/service_parser_test.go
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package buildin_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/apache/servicecomb-service-center/pkg/rest"
+	"github.com/apache/servicecomb-service-center/server/plugin/auth/buildin"
+	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
+	rbacsvc "github.com/apache/servicecomb-service-center/server/service/rbac"
+	pb "github.com/go-chassis/cari/discovery"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	rbacsvc.InitResourceMap()
+}
+
+func TestByServiceKey(t *testing.T) {
+	t.Run("discover nothing should return empty scope", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, buildin.APIDiscovery, nil)
+		req = req.WithContext(context.WithValue(req.Context(), rest.CtxMatchPattern, buildin.APIDiscovery))
+		resp, err := buildin.ByServiceKey(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "service", resp.Type)
+		assert.Equal(t, "get", resp.Verb)
+		assert.NotEmpty(t, resp.Labels)
+		labels := resp.Labels[0]
+		assert.Equal(t, "", labels["environment"])
+		assert.Equal(t, "", labels["appId"])
+		assert.Equal(t, "", labels["serviceName"])
+	})
+
+	t.Run("discover provider 'test' should return 'test' scope", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, buildin.APIDiscovery+"?appId=default&serviceName=test", nil)
+
+		service, err := discosvc.RegisterService(req.Context(), &pb.CreateServiceRequest{Service: &pb.MicroService{
+			ServiceName: "consumer",
+		}})
+		assert.NoError(t, err)
+		defer discosvc.UnregisterService(req.Context(), &pb.DeleteServiceRequest{ServiceId: service.ServiceId})
+
+		req.Header.Set("X-ConsumerId", service.ServiceId)
+		req = req.WithContext(context.WithValue(req.Context(), rest.CtxMatchPattern, buildin.APIDiscovery))
+		resp, err := buildin.ByServiceKey(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "service", resp.Type)
+		assert.Equal(t, "get", resp.Verb)
+		assert.NotEmpty(t, resp.Labels)
+		labels := resp.Labels[0]
+		assert.Equal(t, "", labels["environment"])
+		assert.Equal(t, "default", labels["appId"])
+		assert.Equal(t, "test", labels["serviceName"])
+	})
+
+	t.Run("discover provider 'test' in development env should return 'test' scope", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, buildin.APIDiscovery+"?appId=default&serviceName=test", nil)
+
+		service, err := discosvc.RegisterService(req.Context(), &pb.CreateServiceRequest{Service: &pb.MicroService{
+			Environment: "development",
+			ServiceName: "consumer",
+		}})
+		assert.NoError(t, err)
+		defer discosvc.UnregisterService(req.Context(), &pb.DeleteServiceRequest{ServiceId: service.ServiceId})
+
+		req.Header.Set("X-ConsumerId", service.ServiceId)
+		req = req.WithContext(context.WithValue(req.Context(), rest.CtxMatchPattern, buildin.APIDiscovery))
+		resp, err := buildin.ByServiceKey(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "service", resp.Type)
+		assert.Equal(t, "get", resp.Verb)
+		assert.NotEmpty(t, resp.Labels)
+		labels := resp.Labels[0]
+		assert.Equal(t, "development", labels["environment"])
+		assert.Equal(t, "default", labels["appId"])
+		assert.Equal(t, "test", labels["serviceName"])
+	})
+
+	t.Run("discover provider 'test' with query env should return 'test' scope", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, buildin.APIDiscovery+"?appId=default&serviceName=test&env=testing", nil)
+
+		service, err := discosvc.RegisterService(req.Context(), &pb.CreateServiceRequest{Service: &pb.MicroService{
+			Environment: "development",
+			ServiceName: "consumer",
+		}})
+		assert.NoError(t, err)
+		defer discosvc.UnregisterService(req.Context(), &pb.DeleteServiceRequest{ServiceId: service.ServiceId})
+
+		req.Header.Set("X-ConsumerId", service.ServiceId)
+		req = req.WithContext(context.WithValue(req.Context(), rest.CtxMatchPattern, buildin.APIDiscovery))
+		resp, err := buildin.ByServiceKey(req)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, "service", resp.Type)
+		assert.Equal(t, "get", resp.Verb)
+		assert.NotEmpty(t, resp.Labels)
+		labels := resp.Labels[0]
+		assert.Equal(t, "testing", labels["environment"])
+		assert.Equal(t, "default", labels["appId"])
+		assert.Equal(t, "test", labels["serviceName"])
+	})
+}


### PR DESCRIPTION
当前服务发现接口支持：消费方调用接口是如不传query参数env时，按x-consumerId对应服务的environment来发现服务提供方；在RBAC场景下，鉴权器没有考虑这个场景，导致鉴权按query传参env的值判断，不符合预期。

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `go build` `go test` `go fmt` `go vet` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
 - [ ] Never comment source code, delete it.
 - [ ] UT should has "context, subject, expected result" result as test case name, when you call t.Run().
---
