### PR TITLE
fix(1482): The front-end page cannot be displayed normally.

### DIFF
--- a/scripts/docker/build-frontend-image/build.sh
+++ b/scripts/docker/build-frontend-image/build.sh
@@ -42,7 +42,6 @@ cd $SCRIPT_DIR
 
 # copy the conf folder to build-frontend-image/frontend
 cp -rp $PACKAGE_DIR/app $PACKAGE_DIR/conf $PACKAGE_DIR/frontend start.sh frontend
-rm -rf frontend/app/bower_components
 
 chmod 500 frontend/start.sh frontend/frontend
 


### PR DESCRIPTION
This folder named  `bower_components` is required to run in frontend-image. 
