### PR TITLE
Add readiness probe api

### DIFF
--- a/docs/openapi/v4.yaml
+++ b/docs/openapi/v4.yaml
@@ -83,6 +83,32 @@ paths:
           description: 内部错误
           schema:
             $ref: '#/definitions/Error'
+  /v4/{project}/registry/health/readiness:
+    get:
+      description: |
+        服务中心readiness探测接口，确认服务中心是否可以接收请求。
+      parameters:
+        - name: x-domain-name
+          in: header
+          type: string
+          default: default
+        - name: project
+          in: path
+          required: true
+          type: string
+      tags:
+        - base
+      responses:
+        200:
+          description: 状态正常，可以接收请求
+        400:
+          description: 错误的请求
+          schema:
+            $ref: '#/definitions/Error'
+        500:
+          description: 内部错误
+          schema:
+            $ref: '#/definitions/Error'
   /v4/{project}/registry/microservices/{serviceId}:
     get:
       description: |

--- a/pkg/protect/checker.go
+++ b/pkg/protect/checker.go
@@ -1,0 +1,42 @@
+package protect
+
+import (
+	"sync"
+	"time"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
+)
+
+// ProtectionChecker checks whether to do the protection on null instance
+type ProtectionChecker interface {
+	CheckProtection() bool
+}
+
+// DelayedStopProtectChecker means start the protection and close it after some time
+type DelayedStopProtectChecker struct {
+	delay       time.Duration
+	start       time.Time
+	logWhenStop sync.Once
+}
+
+func NewDelayedSuccessChecker(delay time.Duration) *DelayedStopProtectChecker {
+	return &DelayedStopProtectChecker{
+		delay:       delay,
+		start:       time.Now(),
+		logWhenStop: sync.Once{},
+	}
+}
+
+func (d *DelayedStopProtectChecker) CheckProtection() bool {
+	if time.Since(d.start) > d.delay {
+		d.logWhenStop.Do(func() {
+			log.Info("null instance protection stopped")
+		})
+		return false
+	}
+	return true
+}
+
+func GetGlobalProtectionChecker() ProtectionChecker {
+	return globalProtectionChecker
+}

--- a/pkg/protect/checker_test.go
+++ b/pkg/protect/checker_test.go
@@ -1,0 +1,15 @@
+package protect
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDelayedStopProtectChecker_CheckProtection(t *testing.T) {
+	p := NewDelayedSuccessChecker(1 * time.Second)
+	assert.True(t, p.CheckProtection())
+	time.Sleep(p.delay)
+	assert.False(t, p.CheckProtection())
+}

--- a/pkg/protect/protect_test.go
+++ b/pkg/protect/protect_test.go
@@ -12,19 +12,20 @@ func TestIsWithinRestartProtection(t *testing.T) {
 
 	// protection switch off
 	enableInstanceNullProtect = false
-	assert.False(t, IsWithinRestartProtection())
-	// within protection
+	assert.False(t, ShouldProtectOnNullInstance())
+
 	enableInstanceNullProtect = true
-	isWithinProtection = true
-	startupTimestamp = time.Now().Add(-1 * time.Minute).UnixNano()
-	assert.True(t, IsWithinRestartProtection())
+	AlwaysProtection()
+	assert.True(t, ShouldProtectOnNullInstance())
 
 	// protection delay exceed
-	enableInstanceNullProtect = true
-	isWithinProtection = true
-	startupTimestamp = time.Now().Add(-2 * time.Minute).Unix()
-	assert.False(t, IsWithinRestartProtection())
+	restartProtectInterval = 1 * time.Second
+	StartProtectionAndStopDelayed()
+	assert.True(t, ShouldProtectOnNullInstance())
+	time.Sleep(restartProtectInterval)
+	assert.False(t, ShouldProtectOnNullInstance())
 
-	// always false after exceed
-	assert.False(t, IsWithinRestartProtection())
+	// only the first takes effects
+	StartProtectionAndStopDelayed()
+	assert.False(t, ShouldProtectOnNullInstance())
 }

--- a/server/alarm/common.go
+++ b/server/alarm/common.go
@@ -31,6 +31,7 @@ const (
 
 const (
 	IDBackendConnectionRefuse model.ID = "BackendConnectionRefuse"
+	IDScSelfHeartbeatFailed   model.ID = "ScSelfHeartbeatFailed"
 	IDInternalError           model.ID = "InternalError"
 	IDIncrementPullError      model.ID = "IncrementPullError"
 	IDWebsocketOfScSyncerLost model.ID = "WebsocketOfScSyncerLost"

--- a/server/interceptor/interceptors_test.go
+++ b/server/interceptor/interceptors_test.go
@@ -30,7 +30,7 @@ func mockFunc(w http.ResponseWriter, r *http.Request) error {
 	case 1:
 		return errors.New("error")
 	case 0:
-		panic(errors.New("panic"))
+		return errors.New("panic")
 	default:
 		i++
 	}

--- a/server/plugin/auth/buildin/buildin_test.go
+++ b/server/plugin/auth/buildin/buildin_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/form3tech-oss/jwt-go"
 	"github.com/patrickmn/go-cache"
 
 	_ "github.com/apache/servicecomb-service-center/test"
@@ -187,7 +186,7 @@ func TestSetTokenToCache(t *testing.T) {
 	rawToken1 := "**1"
 	rawToken2 := "**2"
 	deleta, _ := time.ParseDuration("10m")
-	claims := &jwt.MapClaims{"exp": float64(time.Now().Add(deleta).Unix())}
+	claims := map[string]interface{}{"exp": float64(time.Now().Add(deleta).Unix())}
 	t.Run("test Cache", func(t *testing.T) {
 		buildin.SetTokenToCache(tokenCache1, rawToken1, claims)
 		buildin.SetTokenToCache(tokenCache1, rawToken2, errors.New("bad token"))

--- a/server/resource/disco/instance_resource.go
+++ b/server/resource/disco/instance_resource.go
@@ -19,17 +19,16 @@ package disco
 
 import (
 	"fmt"
-	"github.com/apache/servicecomb-service-center/pkg/protect"
 	"io"
 	"net/http"
 	"strings"
 
-	"github.com/go-chassis/go-chassis/v2/pkg/codec"
-
 	pb "github.com/go-chassis/cari/discovery"
+	"github.com/go-chassis/go-chassis/v2/pkg/codec"
 
 	"github.com/apache/servicecomb-service-center/datasource"
 	"github.com/apache/servicecomb-service-center/pkg/log"
+	"github.com/apache/servicecomb-service-center/pkg/protect"
 	"github.com/apache/servicecomb-service-center/pkg/rest"
 	"github.com/apache/servicecomb-service-center/pkg/util"
 	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
@@ -169,7 +168,7 @@ func (s *InstanceResource) FindInstances(w http.ResponseWriter, r *http.Request)
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	if len(resp.Instances) == 0 && protect.IsWithinRestartProtection() {
+	if len(resp.Instances) == 0 && protect.ShouldProtectOnNullInstance() {
 		w.WriteHeader(protect.RestartProtectHttpCode)
 		return
 	}
@@ -272,7 +271,7 @@ func (s *InstanceResource) ListInstance(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusNotModified)
 		return
 	}
-	if len(resp.Instances) == 0 && protect.IsWithinRestartProtection() {
+	if len(resp.Instances) == 0 && protect.ShouldProtectOnNullInstance() {
 		w.WriteHeader(protect.RestartProtectHttpCode)
 		return
 	}

--- a/server/rest/controller/v4/main_controller.go
+++ b/server/rest/controller/v4/main_controller.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/apache/servicecomb-service-center/server/service/registry"
+
 	discosvc "github.com/apache/servicecomb-service-center/server/service/disco"
 
 	"github.com/apache/servicecomb-service-center/pkg/rest"
@@ -48,6 +50,7 @@ func (s *MainService) URLPatterns() []rest.Route {
 	return []rest.Route{
 		{Method: http.MethodGet, Path: "/v4/:project/registry/version", Func: s.GetVersion},
 		{Method: http.MethodGet, Path: "/v4/:project/registry/health", Func: s.ClusterHealth},
+		{Method: http.MethodGet, Path: "/v4/:project/registry/health/readiness", Func: s.Readiness},
 	}
 }
 
@@ -58,6 +61,15 @@ func (s *MainService) ClusterHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	rest.WriteResponse(w, r, nil, resp)
+}
+
+func (s *MainService) Readiness(w http.ResponseWriter, r *http.Request) {
+	err := registry.Readiness(r.Context())
+	if err != nil {
+		rest.WriteServiceError(w, err)
+		return
+	}
+	rest.WriteResponse(w, r, nil, nil)
 }
 
 func (s *MainService) GetVersion(w http.ResponseWriter, r *http.Request) {

--- a/server/service/rbac/rbac.go
+++ b/server/service/rbac/rbac.go
@@ -74,6 +74,7 @@ func add2WhiteAPIList() {
 	rbac.Add2WhiteAPIList(APITokenGranter)
 	rbac.Add2WhiteAPIList("/v4/:project/registry/version", "/version")
 	rbac.Add2WhiteAPIList("/v4/:project/registry/health", "/health")
+	rbac.Add2WhiteAPIList("/v4/:project/registry/health/readiness")
 
 	// user can list self permission without account get permission
 	Add2CheckPermWhiteAPIList(APISelfPerms)

--- a/server/service/registry/health.go
+++ b/server/service/registry/health.go
@@ -1,0 +1,16 @@
+package registry
+
+import (
+	"context"
+
+	pb "github.com/go-chassis/cari/discovery"
+
+	"github.com/apache/servicecomb-service-center/server/health"
+)
+
+func Readiness(_ context.Context) error {
+	if err := health.GlobalReadinessChecker().Healthy(); err != nil {
+		return pb.NewError(pb.ErrUnhealthy, err.Error())
+	}
+	return nil
+}

--- a/server/service/registry/health_test.go
+++ b/server/service/registry/health_test.go
@@ -1,0 +1,14 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/servicecomb-service-center/server/health"
+)
+
+func TestReadiness(t *testing.T) {
+	health.SetGlobalReadinessChecker(&health.NullChecker{})
+	assert.NoError(t, Readiness(nil))
+}


### PR DESCRIPTION
Provides an API to do readiness probe, as sc clients want to know is sc is ready to receive the requests.
The original health API is used for liveness probe and instance discovery of sc it self.