### PR TITLE
add re-registration timestamp and update properties when register with instance id 

### DIFF
--- a/server/config/util.go
+++ b/server/config/util.go
@@ -22,6 +22,9 @@ import (
 	"time"
 
 	beego "github.com/beego/beego/v2/server/web"
+
+	"github.com/apache/servicecomb-service-center/pkg/log"
+
 	"github.com/go-chassis/go-archaius"
 	"github.com/iancoleman/strcase"
 	"github.com/spf13/cast"
@@ -55,12 +58,16 @@ func GetString(key, def string, opts ...Option) string {
 func GetBool(key string, def bool, opts ...Option) bool {
 	options := newOptions(key, opts)
 	if archaius.Exist(options.ENV) {
+		log.Info("debug: 1, " + "env: " + options.ENV)
 		return archaius.GetBool(options.ENV, def)
 	}
 	if archaius.Exist(key) {
+		log.Info("debug: 2, " + "key: " + options.ENV)
 		return archaius.GetBool(key, def)
 	}
-	return beego.AppConfig.DefaultBool(options.Standby, def)
+	ret := beego.AppConfig.DefaultBool(options.Standby, def)
+	log.Info("beego : " + options.Standby)
+	return ret
 }
 
 // GetInt return the int type value by specified key

--- a/server/config/util.go
+++ b/server/config/util.go
@@ -22,9 +22,6 @@ import (
 	"time"
 
 	beego "github.com/beego/beego/v2/server/web"
-
-	"github.com/apache/servicecomb-service-center/pkg/log"
-
 	"github.com/go-chassis/go-archaius"
 	"github.com/iancoleman/strcase"
 	"github.com/spf13/cast"
@@ -58,16 +55,12 @@ func GetString(key, def string, opts ...Option) string {
 func GetBool(key string, def bool, opts ...Option) bool {
 	options := newOptions(key, opts)
 	if archaius.Exist(options.ENV) {
-		log.Info("debug: 1, " + "env: " + options.ENV)
 		return archaius.GetBool(options.ENV, def)
 	}
 	if archaius.Exist(key) {
-		log.Info("debug: 2, " + "key: " + options.ENV)
 		return archaius.GetBool(key, def)
 	}
-	ret := beego.AppConfig.DefaultBool(options.Standby, def)
-	log.Info("beego : " + options.Standby)
-	return ret
+	return beego.AppConfig.DefaultBool(options.Standby, def)
 }
 
 // GetInt return the int type value by specified key

--- a/server/service/disco/instance.go
+++ b/server/service/disco/instance.go
@@ -39,8 +39,9 @@ import (
 )
 
 const (
-	defaultMinInterval = 5 * time.Second
-	defaultMinTimes    = 3
+	defaultMinInterval  = 5 * time.Second
+	defaultMinTimes     = 3
+	reRegisterTimestamp = "reRegisterTimestamp"
 )
 
 var (


### PR DESCRIPTION
Adding re-registration timestamp, and generating properties update sync event in case create sync event can't trigger peer engine's instance property update.


实例注册事件推送到对端时，如果对端已有实例，则无法将最新的property推送到对端，这种场景下，添加re-registration timestamp property并且推送update properties 事件以更新对property。