### PR TITLE
sync again when reentry SyncAll

### DIFF
--- a/datasource/manager.go
+++ b/datasource/manager.go
@@ -54,6 +54,7 @@ func Init(opts Options) error {
 	}
 	err = GetSyncManager().SyncAll(context.Background())
 	if err != nil && err != ErrSyncAllKeyExists {
+		log.Fatal("sync all failed", err)
 		return err
 	}
 	err = schema.Init(schema.Options{Kind: opts.Kind})


### PR DESCRIPTION
1. clear sync-all record when disable sync, so reopen sync will sync again, too
2. record not only whether SyncAll done or not, but also the peer SyncAll affects, if peer changed, SyncAll will be done again